### PR TITLE
During restore, perform backup_online_files() late.

### DIFF
--- a/restore.c
+++ b/restore.c
@@ -132,9 +132,6 @@ do_restore(const char *target_time,
 		printf(_("target timeline ID = %u\n"), target_tli);
 	}
 
-	/* backup online WAL and serverlog */
-	backup_online_files(cur_tli != 0 && cur_tli != backup_tli);
-
 	/*
 	 * restore timeline history files and get timeline branches can reach
 	 * recovery target point.
@@ -172,6 +169,9 @@ do_restore(const char *target_time,
 	elog(ERROR_NO_BACKUP, _("no full backup found, can't restore."));
 
 base_backup_found:
+
+	/* first off, backup online WAL and serverlog */
+	backup_online_files(cur_tli != 0 && cur_tli != backup_tli);
 
 	/*
 	 * Clear restore destination, but don't remove $PGDATA.


### PR DESCRIPTION
That is, only after we have determined that we have a valid backup
to restore. This prevents some INFO messages (recently added) to be
shown too soon. Fixes issue #1 