### PR TITLE
Add a check of the system identifier of backup target database

### DIFF
--- a/expected/backup.out
+++ b/expected/backup.out
@@ -75,3 +75,8 @@ HINT: Please execute 'pg_rman validate' to verify the files are correctly copied
 0
 1
 1
+###### BACKUP COMMAND TEST-0012 ######
+###### failure in backup with different system identifier database ######
+ERROR: could not start backup
+DETAIL: system identifier of target database is different from the one of initially configured database
+10

--- a/expected/init.out
+++ b/expected/init.out
@@ -7,6 +7,7 @@ results/init/backup/backup/
 results/init/backup/backup/pg_xlog/
 results/init/backup/backup/srvlog/
 results/init/backup/pg_rman.ini
+results/init/backup/system_identifier
 results/init/backup/timeline_history/
 ###### INIT COMMAND TEST-0002 ######
 ###### success with archive_command and log_directory ######
@@ -16,6 +17,7 @@ results/init/backup/backup/
 results/init/backup/backup/pg_xlog/
 results/init/backup/backup/srvlog/
 results/init/backup/pg_rman.ini
+results/init/backup/system_identifier
 results/init/backup/timeline_history/
 ###### INIT COMMAND TEST-0003 ######
 ###### success without archive_command ######
@@ -28,6 +30,7 @@ results/init/backup/backup/
 results/init/backup/backup/pg_xlog/
 results/init/backup/backup/srvlog/
 results/init/backup/pg_rman.ini
+results/init/backup/system_identifier
 results/init/backup/timeline_history/
 ###### INIT COMMAND TEST-0004 ######
 ###### failure with backup catalog already existed ######

--- a/init.c
+++ b/init.c
@@ -9,6 +9,8 @@
 
 #include "pg_rman.h"
 
+#include "catalog/pg_control.h"
+
 #include <unistd.h>
 #include <dirent.h>
 
@@ -36,6 +38,8 @@ do_init(void)
 
 	struct dirent **dp;
 	int results;
+	uint64      sysid;
+	char        *buffer;
 	if (access(backup_path, F_OK) == 0){
 		results = scandir(backup_path, &dp, selects, NULL);
 		if(results != 0){
@@ -68,6 +72,26 @@ do_init(void)
 		join_path_components(path, pgdata, "postgresql.conf");
 		parse_postgresql_conf(path, &log_directory, &archive_command);
 	}
+
+	/* get system identifier of the current database.*/
+	buffer = read_control_file();
+
+	if(buffer != NULL)
+		sysid = (uint64) ((ControlFileData *) buffer)->system_identifier;
+	pg_free(buffer);
+
+	/* register system identifier of target database. */
+	join_path_components(path, backup_path, SYSTEM_IDENTIFIER_FILE);
+	fp = fopen(path, "wt");
+	if (fp == NULL)
+	{
+		ereport(ERROR,
+			(errcode(ERROR_SYSTEM),
+			 errmsg("could not create pg_rman.ini: %s", strerror(errno))));
+	} else {
+		fprintf(fp, "SYSTEM_IDENTIFIER='%lu'\n", sysid);
+	}
+	fclose(fp);
 
 	/* create pg_rman.ini */
 	join_path_components(path, backup_path, PG_RMAN_INI_FILE);

--- a/pg_rman.h
+++ b/pg_rman.h
@@ -25,20 +25,21 @@
 
 /* Directory/File names */
 #define DATABASE_DIR			"database"
-#define ARCLOG_DIR			"arclog"
-#define SRVLOG_DIR			"srvlog"
+#define ARCLOG_DIR				"arclog"
+#define SRVLOG_DIR				"srvlog"
 #define RESTORE_WORK_DIR		"backup"
-#define PG_XLOG_DIR			"pg_xlog"
+#define PG_XLOG_DIR				"pg_xlog"
 #define PG_TBLSPC_DIR			"pg_tblspc"
-#define TIMELINE_HISTORY_DIR		"timeline_history"
+#define TIMELINE_HISTORY_DIR	"timeline_history"
 #define BACKUP_INI_FILE			"backup.ini"
 #define PG_RMAN_INI_FILE		"pg_rman.ini"
+#define SYSTEM_IDENTIFIER_FILE	"system_identifier"
 #define MKDIRS_SH_FILE			"mkdirs.sh"
 #define DATABASE_FILE_LIST		"file_database.txt"
 #define ARCLOG_FILE_LIST		"file_arclog.txt"
 #define SRVLOG_FILE_LIST		"file_srvlog.txt"
-#define SNAPSHOT_SCRIPT_FILE		"snapshot_script"
-#define PG_BACKUP_LABEL_FILE		"backup_label"
+#define SNAPSHOT_SCRIPT_FILE	"snapshot_script"
+#define PG_BACKUP_LABEL_FILE	"backup_label"
 #define PG_BLACK_LIST			"black_list"
 
 /* Snapshot script command */

--- a/pgut/pgut.c
+++ b/pgut/pgut.c
@@ -53,7 +53,6 @@ static bool		in_cleanup = false;
 int		pgut_log_level = INFO;
 int		pgut_abort_level = ERROR;
 
-static bool parse_pair(const char buffer[], char key[], char value[]);
 
 /* Connection routines */
 static void init_cancel_handler(void);
@@ -825,7 +824,7 @@ get_next_token(const char *src, char *dst, const char *line)
 	return s + i;
 }
 
-static bool
+bool
 parse_pair(const char buffer[], char key[], char value[])
 {
 	const char *start;

--- a/pgut/pgut.h
+++ b/pgut/pgut.h
@@ -232,6 +232,7 @@ extern bool parse_uint32(const char *value, uint32 *result);
 extern bool parse_int64(const char *value, int64 *result);
 extern bool parse_uint64(const char *value, uint64 *result);
 extern bool parse_time(const char *value, time_t *time);
+extern bool parse_pair(const char buffer[], char key[], char value[]);
 
 #define IsSpace(c)		(isspace((unsigned char)(c)))
 #define IsAlpha(c)		(isalpha((unsigned char)(c)))

--- a/sql/backup.sh
+++ b/sql/backup.sh
@@ -65,10 +65,15 @@ function cleanup()
     mkdir -p ${TBLSPC_PATH}
 }
 
-function init_backup()
+function init_database()
 {
-    # cleanup environment
-    cleanup
+    rm -rf ${PGDATA_PATH}
+    rm -fr ${ARCLOG_PATH}
+    rm -fr ${SRVLOG_PATH}
+    rm -fr ${TBLSPC_PATH}
+    mkdir -p ${ARCLOG_PATH}
+    mkdir -p ${SRVLOG_PATH}
+    mkdir -p ${TBLSPC_PATH}
 
     # create new database cluster
     initdb ${USE_DATA_CHECKSUM} --no-locale -D ${PGDATA_PATH} > ${TEST_BASE}/initdb.log 2>&1
@@ -94,8 +99,6 @@ EOF
 
     pgbench -i -s ${SCALE} -p ${TEST_PGPORT} -d pgbench > ${TEST_BASE}/pgbench.log 2>&1
 
-    # init backup catalog
-    init_catalog
 }
 
 function init_catalog()
@@ -104,7 +107,9 @@ function init_catalog()
     pg_rman init -B ${BACKUP_PATH} --quiet
 }
 
-init_backup
+cleanup
+init_database
+init_catalog
 
 echo '###### BACKUP COMMAND TEST-0001 ######'
 echo '###### full backup mode ######'
@@ -262,6 +267,14 @@ pg_rman validate -B ${BACKUP_PATH} --quiet
 pg_rman show detail -B ${BACKUP_PATH} > ${TEST_BASE}/TEST-0011.log 2>&1
 grep OK ${TEST_BASE}/TEST-0011.log | grep FULL | wc -l
 grep ERROR ${TEST_BASE}/TEST-0011.log | grep ARCH | wc -l
+
+echo '###### BACKUP COMMAND TEST-0012 ######'
+echo '###### failure in backup with different system identifier database ######'
+init_catalog
+pg_ctl stop -m immediate > /dev/null 2>&1
+init_database
+pg_rman backup -B ${BACKUP_PATH} -b full -p ${TEST_PGPORT} -d postgres --quiet;echo $?
+
 
 # cleanup
 ## clean up the temporal test data


### PR DESCRIPTION
In current implementation, pg_rman check the timeline of backup target database in taking an incremental backup. This makes pg_rman can take an incremental backup from the database with the same timeline but the different system identifier.
 
The walreceiver process does checking the system identifier in starting to receive WAL stream.
This patch makes pg_rman does the similar.The system identifier of target database is registered in pg_rman init command and checked in pg_rman backup command.

Regards,