### PR TITLE
Add support for non-exclusive backup API of PG 9.6+.

### DIFF
--- a/pg_rman.h
+++ b/pg_rman.h
@@ -40,6 +40,7 @@
 #define SRVLOG_FILE_LIST		"file_srvlog.txt"
 #define SNAPSHOT_SCRIPT_FILE	"snapshot_script"
 #define PG_BACKUP_LABEL_FILE	"backup_label"
+#define PG_TBLSPC_MAP_FILE		"tablespace_map"
 #define PG_BLACK_LIST			"black_list"
 
 /* Snapshot script command */

--- a/pgut/pgut.c
+++ b/pgut/pgut.c
@@ -43,6 +43,7 @@ YesNo	prompt_password = DEFAULT;
 
 /* Database connections */
 PGconn	   *connection = NULL;
+PGconn	   *saved_connection = NULL;
 static PGcancel *volatile cancel_conn = NULL;
 
 /* Interrupted by SIGINT (Ctrl+C) ? */
@@ -976,6 +977,30 @@ disconnect(void)
 		PQfinish(connection);
 		connection = NULL;
 	}
+}
+
+/*
+ * Like reconnect(), but instead of discarding the old connection, save it
+ * to be restored later.
+ */
+PGconn *
+save_connection(void)
+{
+	Assert(connection != NULL);
+
+	saved_connection = connection;
+	return connection = pgut_connect();
+}
+
+/*
+ * Restore saved connection.
+ */
+void
+restore_saved_connection(void)
+{
+	Assert(saved_connection != NULL);
+
+	connection = saved_connection;
 }
 
 /*  set/get host and port for connecting standby server */

--- a/pgut/pgut.h
+++ b/pgut/pgut.h
@@ -118,6 +118,8 @@ extern int pgut_wait(int num, PGconn *connections[], struct timeval *timeout);
 
 extern PGconn *reconnect(void);
 extern void disconnect(void);
+extern PGconn *save_connection(void);
+extern void restore_saved_connection(void);
 
 extern const char *pgut_get_host(void);
 extern const char *pgut_get_port(void);


### PR DESCRIPTION
One of the main requirements is to use the same connection to issue both
pg_start_backup() and pg_stop_backup().  So this commit introduces new
connection functions save_connection() and restore_saved_connection()
so that when taking backup from standby we don't just throw away the
connection to primary.

Further, backup_label is no longer written to $PGDATA by pg_start_backup().
Instead, pg_stop_backup() returns backup_label text which then needs to be
written to backup root directory.  This commit adds support routines for
that and removes all code which depends on backup_label file being present
in $PGDATA.  In addition to backup_label, it also returns optional
tablespace_map which is a new field that similarly needs to be written
to backup directory.

wait_for_archive() needed to be made to accept parameters.

Finally, we no longer issue pg_stop_backup() in error paths as simply
disconnecting causes server to abort a backup.

For issue #26 