### PR TITLE
#55 rename pg_xlog

### DIFF
--- a/backup.c
+++ b/backup.c
@@ -1149,7 +1149,7 @@ wait_for_archive(pgBackup *backup, const char *sql, int nParams,
 	/* get filename from the result of pg_xlogfile_name_offset() */
 	elog(DEBUG, "waiting for %s is archived", PQgetvalue(res, 0, 0));
 	snprintf(ready_path, lengthof(ready_path),
-		"%s/pg_xlog/archive_status/%s.ready", pgdata, PQgetvalue(res, 0, 0));
+		"%s/pg_wal/archive_status/%s.ready", pgdata, PQgetvalue(res, 0, 0));
 
 	PQclear(res);
 

--- a/dir.c
+++ b/dir.c
@@ -21,7 +21,7 @@
 /* directory exclusion list for backup mode listing */
 const char *pgdata_exclude[] =
 {
-	"pg_xlog",
+	"pg_wal",
 	"pg_stat_tmp",
 	"pgsql_tmp",
 	NULL,			/* arclog_path will be set later */

--- a/expected/init.out
+++ b/expected/init.out
@@ -4,7 +4,7 @@
 0
 results/init/backup/
 results/init/backup/backup/
-results/init/backup/backup/pg_xlog/
+results/init/backup/backup/pg_wal/
 results/init/backup/backup/srvlog/
 results/init/backup/pg_rman.ini
 results/init/backup/system_identifier
@@ -14,7 +14,7 @@ results/init/backup/timeline_history/
 0
 results/init/backup/
 results/init/backup/backup/
-results/init/backup/backup/pg_xlog/
+results/init/backup/backup/pg_wal/
 results/init/backup/backup/srvlog/
 results/init/backup/pg_rman.ini
 results/init/backup/system_identifier
@@ -27,7 +27,7 @@ HINT: Please set ARCLOG_PATH in pg_rman.ini or environmental variable.
 0
 results/init/backup/
 results/init/backup/backup/
-results/init/backup/backup/pg_xlog/
+results/init/backup/backup/pg_wal/
 results/init/backup/backup/srvlog/
 results/init/backup/pg_rman.ini
 results/init/backup/system_identifier

--- a/pg_rman.h
+++ b/pg_rman.h
@@ -28,7 +28,7 @@
 #define ARCLOG_DIR				"arclog"
 #define SRVLOG_DIR				"srvlog"
 #define RESTORE_WORK_DIR		"backup"
-#define PG_XLOG_DIR				"pg_xlog"
+#define PG_XLOG_DIR				"pg_wal"
 #define PG_TBLSPC_DIR			"pg_tblspc"
 #define TIMELINE_HISTORY_DIR	"timeline_history"
 #define BACKUP_INI_FILE			"backup.ini"

--- a/restore.c
+++ b/restore.c
@@ -324,7 +324,7 @@ base_backup_found:
 		}
 	}
 
-	/* copy online WAL backup to $PGDATA/pg_xlog */
+	/* copy online WAL backup to $PGDATA/pg_wal */
 	restore_online_files();
 
 	if (check)
@@ -752,7 +752,7 @@ static void
 backup_online_files(bool re_recovery)
 {
 	char work_path[MAXPGPATH];
-	char pg_xlog_path[MAXPGPATH];
+	char pg_wal_path[MAXPGPATH];
 	bool files_exist;
 	parray *files;
 
@@ -761,7 +761,7 @@ backup_online_files(bool re_recovery)
 	
 	elog(INFO, _("copying online WAL files and server log files"));
 
-	/* get list of files in $BACKUP_PATH/backup/pg_xlog */
+	/* get list of files in $BACKUP_PATH/backup/pg_wal */
 	files = parray_new();
 	snprintf(work_path, lengthof(work_path), "%s/%s/%s", backup_path,
 		RESTORE_WORK_DIR, PG_XLOG_DIR);
@@ -782,11 +782,11 @@ backup_online_files(bool re_recovery)
 	}
 
 	/* backup online WAL */
-	snprintf(pg_xlog_path, lengthof(pg_xlog_path), "%s/pg_xlog", pgdata);
+	snprintf(pg_wal_path, lengthof(pg_wal_path), "%s/pg_wal", pgdata);
 	snprintf(work_path, lengthof(work_path), "%s/%s/%s", backup_path,
 		RESTORE_WORK_DIR, PG_XLOG_DIR);
 	dir_create_dir(work_path, DIR_PERMISSION);
-	dir_copy_files(pg_xlog_path, work_path);
+	dir_copy_files(pg_wal_path, work_path);
 
 	/* backup serverlog */
 	snprintf(work_path, lengthof(work_path), "%s/%s/%s", backup_path,
@@ -803,7 +803,7 @@ restore_online_files(void)
 	char	root_backup[MAXPGPATH];
 	parray *files_backup;
 
-	/* get list of files in $BACKUP_PATH/backup/pg_xlog */
+	/* get list of files in $BACKUP_PATH/backup/pg_wal */
 	files_backup = parray_new();
 	snprintf(root_backup, lengthof(root_backup), "%s/%s/%s", backup_path,
 		RESTORE_WORK_DIR, PG_XLOG_DIR);


### PR DESCRIPTION
@amit, @bwtakacy 

Renamed some 'pg_xlog' to 'pg_wal'.

I've run 'make installcheck' on both local and travis ci and confirmed that all 11 tests were passed.
The reason of reggresion test failures(#57) seem this renaming.

If there are any problems, please tell me about it.