### PR TITLE
Set default application_name in connecting to PostgreSQL server using another func

### DIFF
--- a/pgut/pgut.c
+++ b/pgut/pgut.c
@@ -921,7 +921,27 @@ pgut_connect(void)
 	/* Start the connection. Loop until we have a password if requested by backend. */
 	for (;;)
 	{
-		conn = PQsetdbLogin(host, port, NULL, NULL, dbname, username, password);
+		int argcount = 7; /* host, port, dbname, use, password, 
+				     fallback_application_name */
+		const char *keywords[argcount];
+		const char *values[argcount];
+
+		keywords[0] = "host";
+		values[0] = host;
+		keywords[1] = "port";
+		values[1] = port;
+		keywords[2] = "dbname";
+		values[2] = dbname;
+		keywords[3] = "user";
+		values[3] = username;
+		keywords[4] = "password";
+		values[4] = password;
+		keywords[5] = "fallback_application_name";
+		values[5] = PROGRAM_NAME;
+		keywords[6] = NULL;
+		values[6] = NULL;
+
+		conn = PQconnectdbParams(keywords, values, true);
 
 		if (PQstatus(conn) == CONNECTION_OK)
 			return conn;


### PR DESCRIPTION
Changed the database connection control function from PQconnect() to PQconnectdbParams() to set the default application_name.

Like vacuumlo() in contrib/vacuumlo/vacuumlo.c, i made both 'keywords' and 'values' fixed size arrays.

Although GetConnection() in src/bin/pg_basebackup/streamutil.c implements fexible size of arrays, this seems to be due to containing connection_string, which will be parsed to muliple pairs of 'keywords' and 'values'.

pg_rman doesn't contain connection_string, so i think it's enough to use fixed size arrays.


I've tested this improvement on 2 cases below.

  - Setting application_name with '--dbname="application_name=pg_foobar"', the application_name is set to 'pg_foobar'
  - Not setting application_name, the application_name is set to 'pg_rman'

I also confirmed that the return values(PGconn *conn) from the both functions are not significantly changed, including conn.connect_timeout. 

Any thought?
