### PR TITLE
Fix improper printf format.

### DIFF
--- a/backup.c
+++ b/backup.c
@@ -877,7 +877,7 @@ do_backup(pgBackupOption bkupopt)
 
 	result = controlFile->system_identifier;
 	pg_free(controlFile);
-	elog(DEBUG, "the system identifier of current target database : %ld", result);
+	elog(DEBUG, "the system identifier of current target database : " UINT64_FORMAT, result);
 	snprintf(sysident_str, sizeof(sysident_str), UINT64_FORMAT, result);
 
 	if ( strcmp(value, sysident_str) != 0)

--- a/init.c
+++ b/init.c
@@ -99,7 +99,7 @@ do_init(void)
 			(errcode(ERROR_SYSTEM),
 			 errmsg("could not create system identifier file: %s", strerror(errno))));
 	else
-		fprintf(fp, "SYSTEM_IDENTIFIER='%lu'\n", sysid);
+		fprintf(fp, "SYSTEM_IDENTIFIER='" UINT64_FORMAT "'\n", sysid);
 
 	fclose(fp);
 


### PR DESCRIPTION
There exists improper printf format for 32-bit environment.
Reported by tomoki-t.

Issue #63 .