### PR TITLE
Fix a bug which restores already deleted data.(#72)

### DIFF
--- a/data.c
+++ b/data.c
@@ -517,10 +517,10 @@ backup_data_file(const char *from_root,
 	}
 	/*
 	 * In incremental backup mode, append a special 0-filled page, with
-	 * lastpage field set to true, to mark the end of relation as of this
+	 * endpoint field set to true, to mark the end of relation as of this
 	 * backup.
-	 * This is used when restoring to truncate any subsequent pages that
-	 * may be present in the previous full backup.
+	 * This is used when restoring the backup, to truncate any subsequent
+	 * pages that may be present in the previous full backup.
 	 * In incremental backup mode, put the endpoint to remember the last
 	 * block number.
 	 */

--- a/data.c
+++ b/data.c
@@ -571,8 +571,8 @@ backup_data_file(const char *from_root,
 		/*
 		 * finalize zstream.
 		 *
-		 * NOTE: We need to this even if we didn't read anything from the file
-		 * but still had to write the 0-filled dummy page.
+		 * NOTE: We need to do this even if we didn't read anything from the
+		 * file but still had to write the 0-filled dummy page.
 		 */
 		if (file->read_size > 0 || header.endpoint)
 		{

--- a/expected/restore.out
+++ b/expected/restore.out
@@ -58,3 +58,15 @@ OK: hard-copy option works well.
 0
 0
 
+###### RESTORE COMMAND TEST-0011 ######
+###### vacuum shrinks a page between full and incremental backups ######
+0
+0
+0
+
+###### RESTORE COMMAND TEST-0012 ######
+###### vacuum shrinks a page between full and incremental backups(compressed) ######
+0
+0
+0
+

--- a/expected/restore_checksum.out
+++ b/expected/restore_checksum.out
@@ -58,3 +58,15 @@ OK: hard-copy option works well.
 0
 0
 
+###### RESTORE COMMAND TEST-0011 ######
+###### vacuum shrinks a page between full and incremental backups ######
+0
+0
+0
+
+###### RESTORE COMMAND TEST-0012 ######
+###### vacuum shrinks a page between full and incremental backups(compressed) ######
+0
+0
+0
+

--- a/pg_rman.h
+++ b/pg_rman.h
@@ -97,8 +97,9 @@ typedef struct BackupPageHeader
     BlockNumber block;          /* block number */
     uint16      hole_offset;    /* number of bytes before "hole" */
     uint16      hole_length;    /* number of bytes in "hole" */
-    bool        endpoint;       /* true at the end of each tables.
-                                   used only for incremental backups */
+    bool        endpoint;       /* If set to true, this page marks the end
+                                   of relation, which means any subsequent
+                                   pages are truncated. */
 } BackupPageHeader;
 
 

--- a/pg_rman.h
+++ b/pg_rman.h
@@ -88,6 +88,20 @@ typedef struct pgBackupRange
 	time_t	end;			/* begin +1 when one backup is target */
 } pgBackupRange;
 
+/*
+ * Along with each data page, the following information is written to the
+ * backup.
+ */
+typedef struct BackupPageHeader
+{
+    BlockNumber block;          /* block number */
+    uint16      hole_offset;    /* number of bytes before "hole" */
+    uint16      hole_length;    /* number of bytes in "hole" */
+    bool        endpoint;       /* true at the end of each tables.
+                                   used only for incremental backups */
+} BackupPageHeader;
+
+
 #define pgBackupRangeIsValid(range)	\
 	(((range)->begin != (time_t) 0) || ((range)->end != (time_t) 0))
 #define pgBackupRangeIsSingle(range) \


### PR DESCRIPTION
Usually, vacuum doesn't change table file size, but it shrinks
pages when one or more pages at the end of a table are deleted.

pg_rman doesn't consider this case, so when this type of vacuum
runs between full backup and incremental backup, pg_rman restores
already deleted data.

This is a patch for this case.
 It adds a flag in BackupPageHeader which indicates the end of tables
 during incremental backup.
When recovering, it truncates tables after this flag found.

Could anyone review this patch?

BTW, I also think it's necessary to add a regression test for this case, 
but thiswork has not done yet.