### PR TITLE
Fix-build error on BlockNumber (add storage/block.h)

### DIFF
--- a/pg_rman.h
+++ b/pg_rman.h
@@ -18,6 +18,7 @@
 #include "pgut/pgut.h"
 #include "access/xlogdefs.h"
 #include "storage/bufpage.h"
+#include "storage/block.h"
 #include "utils/pg_crc.h"
 #include "parray.h"
 


### PR DESCRIPTION
PostgreSQL 9.3 version or later is a "storage/block.h" on include "src/include/storage/bufpage.h" header file, so PostgreSQL 9.3 version or later is no build errors appear.
In case of PostgreSQL9.2, It's "storage/block.h"is not added and a build error occurs.
To solve this, included the "storage/block.h" to "pg_rman.h".