### PR TITLE
This patch fixes an error that causes the backup file to a huge size #76

### DIFF
--- a/backup.c
+++ b/backup.c
@@ -1456,6 +1456,12 @@ backup_files(const char *from_root,
 				(errcode(ERROR_INTERRUPTED),
 				 errmsg("interrupted during backup")));
 
+		/* For correct operation of incremental backup, 
+		 * initialize prev_file_not_found variable to false of 
+		 * checking to next backup files.
+		 */
+		prev_file_not_found = false;
+		
 		/* print progress in verbose mode */
 		if (verbose)
 		{


### PR DESCRIPTION
When incremental backup is an operation, all data will be backed up when back up files that did not exist in the previous backup file.
The variable to distinguish it is prev_file_not_found. 
If the "prev_file_not_found" variable value is true, it is recognized as a new file.
However, after the "prev_file_not_found" variable value is changed to true, it is not initialized when the next file is checked. 
Therefore, if the LSN is changed, the old file will be operated as a full backup instead of the incremental backup.
Therefore,an error that can make the file of the incremental backup larger.
So "prev_file_not_found" variable to initialize value false, each time checking the files.

However, this error does not cause a problem in the restore operation.
It is just an error that the size of the incremental backup file becomes large.

Reported-by: lchch 