### PR TITLE
Fixes an error that causes the backup file to a huge size in some situations when running incremental backups.

### DIFF
--- a/backup.c
+++ b/backup.c
@@ -1469,6 +1469,12 @@ backup_files(const char *from_root,
 				(errcode(ERROR_INTERRUPTED),
 				 errmsg("interrupted during backup")));
 
+		/* For correct operation of incremental backup, 
+		 * initialize prev_file_not_found variable to false of 
+		 * checking to next backup files.
+		 */
+		prev_file_not_found = false;
+		
 		/* print progress in verbose mode */
 		if (verbose)
 		{


### PR DESCRIPTION
In backup_files(), we forgot to reset prev_file_not_found, which once set, causes subsequent files to assume the same value resulting in redundant copying of data.
(Merge to REL9_3_STABLE branch)