### PR TITLE
Meaningless incremental backup issue

### DIFF
--- a/backup.c
+++ b/backup.c
@@ -104,7 +104,7 @@ do_backup_database(parray *backup_list, pgBackupOption bkupopt)
 			pgBackup   *prev_backup;
 
 			/* find last completed database backup */
-			prev_backup = catalog_get_last_data_backup(backup_list);
+			prev_backup = catalog_get_last_data_backup(backup_list, true);
 			if (prev_backup == NULL)
 			{
 				if (current.full_backup_on_error)
@@ -193,7 +193,7 @@ do_backup_database(parray *backup_list, pgBackupOption bkupopt)
 		uint32		xlogid, xrecoff;
 
 		/* find last completed database backup */
-		prev_backup = catalog_get_last_data_backup(backup_list);
+		prev_backup = catalog_get_last_data_backup(backup_list, true);
 		if (prev_backup == NULL || prev_backup->tli != current.tli)
 		{
 			if (current.full_backup_on_error)

--- a/catalog.c
+++ b/catalog.c
@@ -266,7 +266,7 @@ err_proc:
  * Find the last completed database backup from the backup list.
  */
 pgBackup *
-catalog_get_last_data_backup(parray *backup_list)
+catalog_get_last_data_backup(parray *backup_list, bool isFull)
 {
 	int			i;
 	pgBackup   *backup = NULL;
@@ -275,6 +275,13 @@ catalog_get_last_data_backup(parray *backup_list)
 	for (i = 0; i < parray_num(backup_list); i++)
 	{
 		backup = (pgBackup *) parray_get(backup_list, i);
+
+		/*
+		 * If a search for a full backup file(isFull),
+		 * ignore everything except BACKUP_MODE_FULL mode backup files.
+		 */
+		if (isFull && backup->backup_mode != BACKUP_MODE_FULL)
+			continue;
 
 		/* we need completed database backup */
 		if (backup->status == BACKUP_STATUS_OK && HAVE_DATABASE(backup))

--- a/delete.c
+++ b/delete.c
@@ -28,6 +28,15 @@ do_delete(pgBackupRange *range, bool force)
 	char 	backup_timestamp[20];
 	char 	given_timestamp[20];
 
+	if (force)
+		ereport(WARNING,
+			(errmsg("Problems can occur that make recovery impossible."),
+			 errdetail("If the backup file is deleted using the force option,"
+				 " an incremental backup file that cannot be used may be"
+				 " left behind depending on the case. If cannot restore using"
+				 " an incremental backup file in such a case,"
+				 " it is need to perform a FULL backup.")));
+
 	/* DATE are always required */
 	if (!pgBackupRangeIsValid(range))
 		ereport(ERROR,

--- a/pg_rman.h
+++ b/pg_rman.h
@@ -286,7 +286,7 @@ extern void pgBackupValidate(pgBackup *backup, bool size_only, bool for_get_time
 /* in catalog.c */
 extern pgBackup *catalog_get_backup(time_t timestamp);
 extern parray *catalog_get_backup_list(const pgBackupRange *range);
-extern pgBackup *catalog_get_last_data_backup(parray *backup_list);
+extern pgBackup *catalog_get_last_data_backup(parray *backup_list, bool isFull);
 extern pgBackup *catalog_get_last_arclog_backup(parray *backup_list);
 extern pgBackup *catalog_get_last_srvlog_backup(parray *backup_list);
 


### PR DESCRIPTION
The pg_rman so far confirmed that there is a backup file that matches the current timelineID with the conditions that allow got of incremental backups.
Because when the backup file is deleted, checked the timelineID for the reason that the full backup file is not easily deleted (check the dependency of the incremental backup file and the full backup file). But due to the vulnerability of the -f option did not consider it.
Because it occurs to this problem, sometimes get incremental backups that unusable.
Therefore, the condition was corrected to confirm that there is a Full backup file that matches the current timelineID.
Besides, when deleting a backup file using the -f option, a warning message indicating that an unusable incremental backup may remain is output.