### PR TITLE
Read pg_control file only when --check option is enabled in restore

### DIFF
--- a/restore.c
+++ b/restore.c
@@ -70,6 +70,7 @@ do_restore(const char *target_time,
 
 	ControlFileData		*controlFile;
 	bool		crc_ok;
+	char		ControlFilePath[MAXPGPATH];
 
 	/* PGDATA and ARCLOG_PATH are always required */
 	if (pgdata == NULL)
@@ -124,13 +125,26 @@ do_restore(const char *target_time,
 			(errcode(ERROR_SYSTEM),
 			 errmsg("could not get list of backup already taken")));
 
-	controlFile = get_controlfile(pgdata, "pg_rman", &crc_ok);
-	if (!crc_ok)
-		ereport(WARNING,
-				(errmsg("control file appears to be corrupt"),
-				 errdetail("Calculated CRC checksum does not match value stored in file.")));
-	wal_segment_size = controlFile->xlog_seg_size;
-	pg_free(controlFile);
+	/* get wal_segment_size from pg_control file, it is needed for check option. */
+	if (check)
+	{
+		snprintf(ControlFilePath, MAXPGPATH, "%s/global/pg_control", pgdata);
+		if (fileExists(ControlFilePath))
+		{
+			controlFile = get_controlfile(pgdata, "pg_rman", &crc_ok);
+			if (!crc_ok)
+				ereport(ERROR,
+						(errmsg("control file appears to be corrupt"),
+						 errdetail("Calculated CRC checksum does not match value stored in file.")));
+			wal_segment_size = controlFile->xlog_seg_size;
+			pg_free(controlFile);
+		}
+		else
+		{
+			elog(ERROR, _("pg_controldata file \"%s\" does not exist"),
+				 ControlFilePath);
+		}
+	}
 
 	cur_tli = get_current_timeline();
 	elog(DEBUG, "the current timeline ID of database cluster is %d", cur_tli);

--- a/restore.c
+++ b/restore.c
@@ -70,7 +70,6 @@ do_restore(const char *target_time,
 
 	ControlFileData		*controlFile;
 	bool		crc_ok;
-	char		ControlFilePath[MAXPGPATH];
 
 	/* PGDATA and ARCLOG_PATH are always required */
 	if (pgdata == NULL)
@@ -125,23 +124,13 @@ do_restore(const char *target_time,
 			(errcode(ERROR_SYSTEM),
 			 errmsg("could not get list of backup already taken")));
 
-	snprintf(ControlFilePath, MAXPGPATH, "%s/global/pg_control", pgdata);
-	if (fileExists(ControlFilePath))
-	{
-		controlFile = get_controlfile(pgdata, "pg_rman", &crc_ok);
-		if (!crc_ok)
-			ereport(WARNING,
-					(errmsg("control file appears to be corrupt"),
-					 errdetail("Calculated CRC checksum does not match value stored in file.")));
-		wal_segment_size = controlFile->xlog_seg_size;
-		pg_free(controlFile);
-	}
-	else
-	{
-		elog(WARNING, _("pg_controldata file \"%s\" does not exist"),
-			 ControlFilePath);
-		wal_segment_size = DEFAULT_XLOG_SEG_SIZE;
-	}
+	controlFile = get_controlfile(pgdata, "pg_rman", &crc_ok);
+	if (!crc_ok)
+		ereport(WARNING,
+				(errmsg("control file appears to be corrupt"),
+				 errdetail("Calculated CRC checksum does not match value stored in file.")));
+	wal_segment_size = controlFile->xlog_seg_size;
+	pg_free(controlFile);
 
 	cur_tli = get_current_timeline();
 	elog(DEBUG, "the current timeline ID of database cluster is %d", cur_tli);


### PR DESCRIPTION
This is correction for #114, the second version patch based on discussion in #119 .
The target is PostgreSQL 11 and later.

In restore processing, pg_rman always had read the pg_control file from target database cluster.
However, if the database cluster had been deleted completely, pg_rman restore was failed because of calling get_controlfile().
The information of pg_control file in old database cluster is used only by --check option.
It is not necessarily required for database restore.

This patch modify to read pg_control file only when --check option is enabled in restore process.
Also, this introduce file existence check.
If --check option is specified and pg_control file is not found in restore process, pg_rman reports ERROR and interrupts processing.
