### PR TITLE
Fix to avoid buffer overflow.

### DIFF
--- a/backup.c
+++ b/backup.c
@@ -134,7 +134,7 @@ do_backup_database(parray *backup_list, pgBackupOption bkupopt)
 
 	/* notify start of backup to PostgreSQL server */
 	time2iso(label, lengthof(label), current.start_time);
-	strncat(label, " with pg_rman", lengthof(label));
+	strncat(label, " with pg_rman", lengthof(label) - strlen(label) - 1);
 	pg_start_backup(label, smooth_checkpoint, &current);
 
 	/* Execute restartpoint on standby once replay reaches the backup LSN */


### PR DESCRIPTION
Now, the buffer overflow which this patch handles doesn't happen
without this patch. But, it need to avoid the buffer overflow
even if the output message is changed in the future.