### PR TITLE
Add '--recovery-target-action' option for restore(#182)

### DIFF
--- a/docs/index-ja.html
+++ b/docs/index-ja.html
@@ -640,6 +640,12 @@ $ pg_ctl start
 <ul>
 <li>指定したリカバリ対象の直後で停止する (true) か、リカバリ対象の直前で停止する (false) かを指定します。デフォルトは true です。</li>
 </ul>
+
+<li><strong><code>--recovery-target-action {{ pause | promote | shutdown }}</code></strong>
+
+<ul>
+<li>リカバリ対象に到達した場合に、サーバがする動作を指定します。 デフォルトはpauseで、リカバリを休止することを意味します。 promoteは、リカバリの過程が終われば、サーバは接続の受け付けを始めることを意味します。 最後に、shutdownは、リカバリ対象に到達した後にサーバを停止します。1.3.12よりも後のバージョンで利用可能です。</li>
+</ul>
 </li>
 </ul>
 
@@ -987,6 +993,14 @@ $ pg_ctl start
 <td>指定可</td>
 <td>リカバリ到達点自体をリカバリするか</td>
 <td></td>
+</tr>
+<tr>
+<td></td>
+<td>&ndash;recovery-target-action</td>
+<td>RECOVERY_TARGET_ACTION</td>
+<td>指定可</td>
+<td>リカバリ対象に到達した場合にサーバがする動作</td>
+<td>1.3.12よりも後のバージョンで利用可能</td>
 </tr>
 <tr>
 <td></td>

--- a/docs/index.html
+++ b/docs/index.html
@@ -613,6 +613,13 @@ $ pg_ctl start
 <li>Specifies whether we stop just after the specified recovery target (true), or just before the recovery target (false). Default is true. 
 </ul>
 </li>
+<li><strong><code>--recovery-target-action {{ pause | promote | shutdown }}</code></strong>
+
+<ul>
+<li>Specifies what action the server should take once the recovery target is reached. The default is pause, which means recovery will be paused. promote means the recovery process will finish and the server will start to accept connections. Finally shutdown will stop the server after reaching the recovery target. This option is provided version higher than 1.3.12.</li>
+</ul>
+</li>
+</ul>
 </li>
 </ul>
 
@@ -958,6 +965,14 @@ $ pg_ctl start
 <td>Yes</td>
 <td>whether we stop just after the recovery target</td>
 <td></td>
+</tr>
+<tr>
+<td></td>
+<td>&ndash;recovery-target-action</td>
+<td>RECOVERY_TARGET_ACTION</td>
+<td>Yes</td>
+<td>action the server should take once the recovery target is reached</td>
+<td>This option is provided versions higher than 1.3.12</td>
 </tr>
 <tr>
 <td></td>

--- a/expected/option.out
+++ b/expected/option.out
@@ -45,6 +45,7 @@ Restore options:
   --recovery-target-xid     transaction ID up to which recovery will proceed
   --recovery-target-inclusive whether we stop just after the recovery target
   --recovery-target-timeline  recovering into a particular timeline
+  --recovery-target-action    action the server should take once the recovery target is reached
   --hard-copy                 copying archivelog not symbolic link
 
 Catalog options:

--- a/expected/restore.out
+++ b/expected/restore.out
@@ -47,24 +47,54 @@ OK: recovery-target-xid options works well.
 OK: recovery-target-inclusive=false works well.
 
 ###### RESTORE COMMAND TEST-0009 ######
+###### recovery with target action pause ######
+recovery-target-action=pause
+0
+0
+0
+0
+0
+OK: not promoted. recovery-target-action works well.
+
+###### RESTORE COMMAND TEST-0010 ######
+###### recovery with target action promote ######
+recovery-target-action=promote
+0
+0
+0
+0
+0
+OK: promoted. recovery-target-action works well.
+
+###### RESTORE COMMAND TEST-0011 ######
+###### recovery with target action shutdown ######
+recovery-target-action=shutdown
+0
+0
+0
+0
+0
+OK: server is stopped. recovery-target-action works well.
+
+###### RESTORE COMMAND TEST-0012 ######
 ###### recovery with hard-copy option ######
 0
 0
 OK: hard-copy option works well.
 
-###### RESTORE COMMAND TEST-0010 ######
+###### RESTORE COMMAND TEST-0013 ######
 ###### recovery from incremental backup after database creation ######
 0
 0
 0
 
-###### RESTORE COMMAND TEST-0011 ######
+###### RESTORE COMMAND TEST-0014 ######
 ###### vacuum shrinks a page between full and incremental backups ######
 0
 0
 0
 
-###### RESTORE COMMAND TEST-0012 ######
+###### RESTORE COMMAND TEST-0015 ######
 ###### vacuum shrinks a page between full and incremental backups(compressed) ######
 0
 0

--- a/expected/restore_checksum.out
+++ b/expected/restore_checksum.out
@@ -47,24 +47,54 @@ OK: recovery-target-xid options works well.
 OK: recovery-target-inclusive=false works well.
 
 ###### RESTORE COMMAND TEST-0009 ######
+###### recovery with target action pause ######
+recovery-target-action=pause
+0
+0
+0
+0
+0
+OK: not promoted. recovery-target-action works well.
+
+###### RESTORE COMMAND TEST-0010 ######
+###### recovery with target action promote ######
+recovery-target-action=promote
+0
+0
+0
+0
+0
+OK: promoted. recovery-target-action works well.
+
+###### RESTORE COMMAND TEST-0011 ######
+###### recovery with target action shutdown ######
+recovery-target-action=shutdown
+0
+0
+0
+0
+0
+OK: server is stopped. recovery-target-action works well.
+
+###### RESTORE COMMAND TEST-0012 ######
 ###### recovery with hard-copy option ######
 0
 0
 OK: hard-copy option works well.
 
-###### RESTORE COMMAND TEST-0010 ######
+###### RESTORE COMMAND TEST-0013 ######
 ###### recovery from incremental backup after database creation ######
 0
 0
 0
 
-###### RESTORE COMMAND TEST-0011 ######
+###### RESTORE COMMAND TEST-0014 ######
 ###### vacuum shrinks a page between full and incremental backups ######
 0
 0
 0
 
-###### RESTORE COMMAND TEST-0012 ######
+###### RESTORE COMMAND TEST-0015 ######
 ###### vacuum shrinks a page between full and incremental backups(compressed) ######
 0
 0

--- a/pg_rman.c
+++ b/pg_rman.c
@@ -48,6 +48,7 @@ static char		   *target_time;
 static char		   *target_xid;
 static char		   *target_inclusive;
 static char		   *target_tli_string;
+static char		   *target_action;
 static bool		is_hard_copy = false;
 
 /* delete configuration */
@@ -92,7 +93,8 @@ static pgut_option options[] =
 	{ 's',  8, "recovery-target-xid"		, &target_xid		, SOURCE_ENV },
 	{ 's',  9, "recovery-target-inclusive"	, &target_inclusive	, SOURCE_ENV },
 	{ 's', 10, "recovery-target-timeline"	, &target_tli_string, SOURCE_ENV },
-	{ 'b', 11, "hard-copy"	, &is_hard_copy		, SOURCE_ENV },
+	{ 's', 11, "recovery-target-action"		, &target_action	, SOURCE_ENV },
+	{ 'b', 12, "hard-copy"	, &is_hard_copy		, SOURCE_ENV },
 	/* catalog options */
 	{ 'b', 'a', "show-all"		, &show_all },
 	{ 0 }
@@ -221,7 +223,7 @@ main(int argc, char *argv[])
 	}
 	else if (pg_strcasecmp(cmd, "restore") == 0)
 		return do_restore(target_time, target_xid,
-					target_inclusive, target_tli_string, is_hard_copy);
+					target_inclusive, target_tli_string, target_action, is_hard_copy);
 	else if (pg_strcasecmp(cmd, "show") == 0)
 		return do_show(&range, show_detail, show_all);
 	else if (pg_strcasecmp(cmd, "validate") == 0)
@@ -285,6 +287,7 @@ pgut_help(bool details)
 	printf(_("  --recovery-target-xid     transaction ID up to which recovery will proceed\n"));
 	printf(_("  --recovery-target-inclusive whether we stop just after the recovery target\n"));
 	printf(_("  --recovery-target-timeline  recovering into a particular timeline\n"));
+	printf(_("  --recovery-target-action    action the server should take once the recovery target is reached\n"));
 	printf(_("  --hard-copy                 copying archivelog not symbolic link\n"));
 	printf(_("\nCatalog options:\n"));
 	printf(_("  -a, --show-all            show deleted backup too\n"));

--- a/pg_rman.h
+++ b/pg_rman.h
@@ -219,6 +219,7 @@ typedef struct pgRecoveryTarget
 	bool		xid_specified;
 	unsigned int	recovery_target_xid;
 	bool		recovery_target_inclusive;
+	const char	*recovery_target_action;
 } pgRecoveryTarget;
 
 typedef enum CompressionMode
@@ -265,6 +266,7 @@ extern int do_restore(const char *target_time,
 					  const char *target_xid,
 					  const char *target_inclusive,
 					  const char *target_tli_string,
+					  const char *target_action,
 					  bool is_hard_copy);
 
 /* in init.c */

--- a/restore.c
+++ b/restore.c
@@ -23,11 +23,13 @@ static void restore_archive_logs(pgBackup *backup, bool is_hard_copy);
 static void create_recovery_conf(const char *target_time,
 								 const char *target_xid,
 								 const char *target_inclusive,
+								 const char *target_action,
 								 TimeLineID target_tli,
 								 bool target_tli_latest);
 static pgRecoveryTarget *checkIfCreateRecoveryConf(const char *target_time,
 								 const char *target_xid,
-								 const char *target_inclusive);
+								 const char *target_inclusive,
+								 const char *target_action);
 static parray * readTimeLineHistory(TimeLineID targetTLI);
 static bool satisfy_timeline(const parray *timelines, const pgBackup *backup);
 static bool satisfy_recovery_target(const pgBackup *backup, const pgRecoveryTarget *rt);
@@ -44,6 +46,7 @@ do_restore(const char *target_time,
 		   const char *target_xid,
 		   const char *target_inclusive,
 		   const char *target_tli_string,
+		   const char *target_action,
 		   bool is_hard_copy)
 {
 	int i;
@@ -103,7 +106,7 @@ do_restore(const char *target_time,
 			 errmsg("PostgreSQL server is running"),
 			 errhint("Please stop PostgreSQL server before exectute restore.")));
 
-	rt = checkIfCreateRecoveryConf(target_time, target_xid, target_inclusive);
+	rt = checkIfCreateRecoveryConf(target_time, target_xid, target_inclusive, target_action);
 	if(rt == NULL)
 		ereport(ERROR,
 			(errcode(ERROR_ARGS),
@@ -340,7 +343,8 @@ base_backup_found:
 	}
 
 	/* create recovery.conf */
-	create_recovery_conf(target_time, target_xid, target_inclusive, target_tli, target_tli_latest);
+	create_recovery_conf(target_time, target_xid, target_inclusive,
+				target_action, target_tli, target_tli_latest);
 
 	/* release catalog lock */
 	catalog_unlock();
@@ -701,6 +705,7 @@ static void
 create_recovery_conf(const char *target_time,
 					 const char *target_xid,
 					 const char *target_inclusive,
+					 const char *target_action,
 					 TimeLineID target_tli,
 					 bool target_tli_latest)
 {
@@ -737,6 +742,8 @@ create_recovery_conf(const char *target_time,
 			fprintf(fp, "recovery_target_timeline = 'latest'\n");
 		else
 			fprintf(fp, "recovery_target_timeline = '%u'\n", target_tli);
+		if (target_action)
+			fprintf(fp, "recovery_target_action = '%s'\n", target_action);
 
 		fclose(fp);
 	}
@@ -1154,7 +1161,8 @@ search_next_wal(const char *path, uint32 *needId, uint32 *needSeg, parray *timel
 static pgRecoveryTarget *
 checkIfCreateRecoveryConf(const char *target_time,
                    const char *target_xid,
-                   const char *target_inclusive)
+                   const char *target_inclusive,
+                   const char *target_action)
 {
 	time_t		dummy_time;
 	unsigned int	dummy_xid;
@@ -1168,6 +1176,7 @@ checkIfCreateRecoveryConf(const char *target_time,
 	rt->recovery_target_time = 0;
 	rt->recovery_target_xid  = 0;
 	rt->recovery_target_inclusive = false;
+	rt->recovery_target_action = NULL;
 
 	if(target_time)
 	{
@@ -1201,6 +1210,21 @@ checkIfCreateRecoveryConf(const char *target_time,
 			ereport(ERROR,
 				(errcode(ERROR_ARGS),
 				 errmsg("could not create recovery.conf with %s", target_inclusive)));
+	}
+
+	if(target_action)
+	{
+		if (pg_strcasecmp("pause", target_action) == 0 ||
+			pg_strcasecmp("promote", target_action) == 0 ||
+			pg_strcasecmp("shutdown", target_action) == 0 )
+		{
+			/* Although this value doesn't be used, set to match "recovery_target_inclusive". */
+			rt->recovery_target_action = target_action;
+		} else
+			ereport(ERROR,
+				(errcode(ERROR_ARGS),
+				 errmsg("could not create recovery.conf or"
+						"add recovery related options to postgresql.conf(after PG12) with %s", target_action)));
 	}
 
 	return rt;

--- a/sql/restore.sh
+++ b/sql/restore.sh
@@ -109,6 +109,88 @@ function init_catalog()
     pg_rman init -B ${BACKUP_PATH} --quiet
 }
 
+function load_with_pgbench
+{
+	pgbench -p ${TEST_PGPORT} -T ${DURATION} -d pgbench > /dev/null 2>&1
+}
+
+function get_database_data
+{
+	psql -p ${TEST_PGPORT} --no-psqlrc -d pgbench -c "SELECT * FROM pgbench_branches;"
+}
+
+function server_is_running
+{
+	# if 1: running, 0: stopped
+	pg_ctl status | grep "server is running" | wc -l
+}
+
+function pg_is_in_recovery
+{
+	psql -tA -p ${TEST_PGPORT} --no-psqlrc -d pgbench -c "SELECT pg_is_in_recovery();"
+}
+
+function full_backup
+{
+	pg_rman backup -B ${BACKUP_PATH} -b full -Z -p ${TEST_PGPORT} -d postgres --quiet;echo $?
+	pg_rman validate -B ${BACKUP_PATH} --quiet; echo $?
+}
+
+function recovery_target_action_test
+{
+	recovery_target_action=$1
+	test_log=$2                   # ${TEST_BASE}/TEST-XXXX
+
+	echo "recovery-target-action=$recovery_target_action"
+
+	init_backup
+
+	# Enable 'hot_standby' to check 'pause' is worked. If hot_standby is 'off',
+	# 'pause' will act the same as 'shutdown'. The default value is 'off' in
+	# 9.6 although it's 'on' since 10, .
+	echo "hot_standby = on" >> ${PGDATA_PATH}/postgresql.conf
+
+	load_with_pgbench
+	full_backup
+	get_database_data > ${test_log}-before.out
+	TARGET_TIME=`date +"%Y-%m-%d %H:%M:%S"`
+	load_with_pgbench
+	full_backup
+	pg_ctl stop -m fast > /dev/null 2>&1
+	pg_rman restore -B ${BACKUP_PATH} --recovery-target-time="${TARGET_TIME}" \
+			 --recovery-target-action="${recovery_target_action}" --quiet;echo $?
+	pg_ctl start -w -t 600 > /dev/null 2>&1
+	sleep 5
+
+	if [ $recovery_target_action = "shutdown" ]; then
+		if [ `server_is_running` = "0" ]; then
+			echo 'OK: server is stopped. recovery-target-action works well.'
+		else
+			echo 'NG: server is running. recovery-target-action does not work well.'
+		fi
+		return;
+	fi
+
+	# check the data records after shutdown check is done
+	get_database_data > ${test_log}-after.out
+	diff ${test_log}-before.out ${test_log}-after.out
+
+	if [ `pg_is_in_recovery` = "f" ]; then
+		if [ $recovery_target_action = "promote" ]; then
+			echo 'OK: promoted. recovery-target-action works well.'
+		else
+			echo 'NG: promoted. recovery-target-action does not work well.'
+		fi
+	else
+		if [ $recovery_target_action = "pause" ]; then
+			echo 'OK: not promoted. recovery-target-action works well.'
+		else
+			echo 'NG: not promoted. recovery-target-action does not work well.'
+		fi
+	fi
+}
+
+
 init_backup
 
 echo '###### RESTORE COMMAND TEST-0001 ######'
@@ -258,12 +340,26 @@ else
 fi
 echo ''
 
-
 echo '###### RESTORE COMMAND TEST-0009 ######'
+echo '###### recovery with target action pause ######'
+recovery_target_action_test pause "${TEST_BASE}/TEST-0009"
+echo ''
+
+echo '###### RESTORE COMMAND TEST-0010 ######'
+echo '###### recovery with target action promote ######'
+recovery_target_action_test promote "${TEST_BASE}/TEST-0010"
+echo ''
+
+echo '###### RESTORE COMMAND TEST-0011 ######'
+echo '###### recovery with target action shutdown ######'
+recovery_target_action_test shutdown "${TEST_BASE}/TEST-0011"
+echo ''
+
+echo '###### RESTORE COMMAND TEST-0012 ######'
 echo '###### recovery with hard-copy option ######'
 init_backup
 pgbench -p ${TEST_PGPORT} -d pgbench > /dev/null 2>&1
-psql --no-psqlrc -p ${TEST_PGPORT} -d pgbench -c "SELECT * FROM pgbench_branches;" > ${TEST_BASE}/TEST-0009-before.out
+psql --no-psqlrc -p ${TEST_PGPORT} -d pgbench -c "SELECT * FROM pgbench_branches;" > ${TEST_BASE}/TEST-0012-before.out
 pg_rman backup -B ${BACKUP_PATH} -b full -Z -p ${TEST_PGPORT} -d postgres --quiet;echo $?
 pg_rman validate -B ${BACKUP_PATH} --quiet
 pg_ctl stop -m immediate > /dev/null 2>&1
@@ -283,67 +379,68 @@ else
 fi
 echo ''
 
-echo '###### RESTORE COMMAND TEST-0010 ######'
+echo '###### RESTORE COMMAND TEST-0013 ######'
 echo '###### recovery from incremental backup after database creation ######'
 init_backup
 pg_ctl start -w -t 600 > /dev/null 2>&1
 pg_rman backup -B ${BACKUP_PATH} -b full -Z -p ${TEST_PGPORT} -d postgres --quiet;echo $?
 pg_rman validate -B ${BACKUP_PATH} --quiet
-createdb db0010 -p ${TEST_PGPORT}
-pgbench -i -s $SCALE -d db0010 -p ${TEST_PGPORT} > ${TEST_BASE}/TEST-0010-db0010-init.out 2>&1
+createdb db0013 -p ${TEST_PGPORT}
+pgbench -i -s $SCALE -d db0013 -p ${TEST_PGPORT} > ${TEST_BASE}/TEST-0013-db0013-init.out 2>&1
 pg_rman backup -B ${BACKUP_PATH} -b incremental -Z -p ${TEST_PGPORT} -d postgres --quiet;echo $?
 pg_rman validate -B ${BACKUP_PATH} --quiet
-pgbench -p ${TEST_PGPORT} -d db0010 >> ${TEST_BASE}/TEST-0010-db0010-init.out 2>&1
-psql --no-psqlrc -p ${TEST_PGPORT} -d db0010 -c "SELECT * FROM pgbench_branches;" > ${TEST_BASE}/TEST-0010-before.out
-pg_ctl stop -m immediate > /dev/null 2>&1
+pgbench -p ${TEST_PGPORT} -d db0013 >> ${TEST_BASE}/TEST-0013-db0013-init.out 2>&1
+psql --no-psqlrc -p ${TEST_PGPORT} -d db0013 -c "SELECT * FROM pgbench_branches;" > ${TEST_BASE}/TEST-0013-before.out
+pg_ctl stop -m fast > /dev/null 2>&1
 pg_rman restore -B ${BACKUP_PATH} --quiet;echo $?
 pg_ctl start -w -t 600 > /dev/null 2>&1
-psql --no-psqlrc -p ${TEST_PGPORT} -d db0010 -c "SELECT * FROM pgbench_branches;" > ${TEST_BASE}/TEST-0010-after.out
-diff ${TEST_BASE}/TEST-0010-before.out ${TEST_BASE}/TEST-0010-after.out
+sleep 1
+psql --no-psqlrc -p ${TEST_PGPORT} -d db0013 -c "SELECT * FROM pgbench_branches;" > ${TEST_BASE}/TEST-0013-after.out
+diff ${TEST_BASE}/TEST-0013-before.out ${TEST_BASE}/TEST-0013-after.out
 echo ''
 
-echo '###### RESTORE COMMAND TEST-0011 ######'
+echo '###### RESTORE COMMAND TEST-0014 ######'
 echo '###### vacuum shrinks a page between full and incremental backups ######'
 init_backup
 pg_ctl start -w -t 600 > /dev/null 2>&1
-createdb db0011 -p ${TEST_PGPORT}
-psql --no-psqlrc -p ${TEST_PGPORT} -d db0011 -c "CREATE TABLE t0011(i int,j int,k varchar);" > /dev/null 2>&1
-psql --no-psqlrc -p ${TEST_PGPORT} -d db0011 -c "INSERT INTO t0011 (i,j,k) select generate_series(1,1000),1, repeat('a', 10);" > /dev/null 2>&1
+createdb db0014 -p ${TEST_PGPORT}
+psql --no-psqlrc -p ${TEST_PGPORT} -d db0014 -c "CREATE TABLE t0014(i int,j int,k varchar);" > /dev/null 2>&1
+psql --no-psqlrc -p ${TEST_PGPORT} -d db0014 -c "INSERT INTO t0014 (i,j,k) select generate_series(1,1000),1, repeat('a', 10);" > /dev/null 2>&1
 pg_rman backup -B ${BACKUP_PATH} -b full -p ${TEST_PGPORT} -d postgres --quiet;echo $?
 pg_rman validate -B ${BACKUP_PATH} --quiet
-psql --no-psqlrc -p ${TEST_PGPORT} -d db0011 -c "DELETE FROM t0011 WHERE i > 10;" > /dev/null 2>&1
-psql --no-psqlrc -p ${TEST_PGPORT} -d db0011 -c "VACUUM t0011;" > /dev/null 2>&1
+psql --no-psqlrc -p ${TEST_PGPORT} -d db0014 -c "DELETE FROM t0014 WHERE i > 10;" > /dev/null 2>&1
+psql --no-psqlrc -p ${TEST_PGPORT} -d db0014 -c "VACUUM t0014;" > /dev/null 2>&1
 pg_rman backup -B ${BACKUP_PATH} -b incremental -p ${TEST_PGPORT} -d postgres --quiet;echo $?
 pg_rman validate -B ${BACKUP_PATH} --quiet
-psql --no-psqlrc -p ${TEST_PGPORT} -d db0011 -c "SELECT * FROM t0011;" > ${TEST_BASE}/TEST-0011-before.out
+psql --no-psqlrc -p ${TEST_PGPORT} -d db0014 -c "SELECT * FROM t0014;" > ${TEST_BASE}/TEST-0014-before.out
 pg_ctl stop -m fast > /dev/null 2>&1
 pg_rman restore -B ${BACKUP_PATH} --quiet;echo $?
 pg_ctl start -w -t 600 > /dev/null 2>&1
 sleep 1
-psql --no-psqlrc -p ${TEST_PGPORT} -d db0011 -c "SELECT * FROM t0011;" > ${TEST_BASE}/TEST-0011-after.out
-diff ${TEST_BASE}/TEST-0011-before.out ${TEST_BASE}/TEST-0011-after.out
+psql --no-psqlrc -p ${TEST_PGPORT} -d db0014 -c "SELECT * FROM t0014;" > ${TEST_BASE}/TEST-0014-after.out
+diff ${TEST_BASE}/TEST-0014-before.out ${TEST_BASE}/TEST-0014-after.out
 echo ''
 
-echo '###### RESTORE COMMAND TEST-0012 ######'
+echo '###### RESTORE COMMAND TEST-0015 ######'
 echo '###### vacuum shrinks a page between full and incremental backups(compressed) ######'
 init_backup
 pg_ctl start -w -t 600 > /dev/null 2>&1
-createdb db0012 -p ${TEST_PGPORT}
-psql --no-psqlrc -p ${TEST_PGPORT} -d db0012 -c "CREATE TABLE t0012(i int,j int,k varchar);" > /dev/null 2>&1
-psql --no-psqlrc -p ${TEST_PGPORT} -d db0012 -c "INSERT INTO t0012 (i,j,k) select generate_series(1,1000),1, repeat('a', 10);" > /dev/null 2>&1
+createdb db0015 -p ${TEST_PGPORT}
+psql --no-psqlrc -p ${TEST_PGPORT} -d db0015 -c "CREATE TABLE t0015(i int,j int,k varchar);" > /dev/null 2>&1
+psql --no-psqlrc -p ${TEST_PGPORT} -d db0015 -c "INSERT INTO t0015 (i,j,k) select generate_series(1,1000),1, repeat('a', 10);" > /dev/null 2>&1
 pg_rman backup -B ${BACKUP_PATH} -b full -Z -p ${TEST_PGPORT} -d postgres --quiet;echo $?
 pg_rman validate -B ${BACKUP_PATH} --quiet
-psql --no-psqlrc -p ${TEST_PGPORT} -d db0012 -c "DELETE FROM t0012 WHERE i > 10;" > /dev/null 2>&1
-psql --no-psqlrc -p ${TEST_PGPORT} -d db0012 -c "VACUUM t0012;" > /dev/null 2>&1
+psql --no-psqlrc -p ${TEST_PGPORT} -d db0015 -c "DELETE FROM t0015 WHERE i > 10;" > /dev/null 2>&1
+psql --no-psqlrc -p ${TEST_PGPORT} -d db0015 -c "VACUUM t0015;" > /dev/null 2>&1
 pg_rman backup -B ${BACKUP_PATH} -b incremental -Z -p ${TEST_PGPORT} -d postgres --quiet;echo $?
 pg_rman validate -B ${BACKUP_PATH} --quiet
-psql --no-psqlrc -p ${TEST_PGPORT} -d db0012 -c "SELECT * FROM t0012;" > ${TEST_BASE}/TEST-0012-before.out
+psql --no-psqlrc -p ${TEST_PGPORT} -d db0015 -c "SELECT * FROM t0015;" > ${TEST_BASE}/TEST-0015-before.out
 pg_ctl stop -m fast > /dev/null 2>&1
 pg_rman restore -B ${BACKUP_PATH} --quiet;echo $?
 pg_ctl start -w -t 600 > /dev/null 2>&1
 sleep 1
-psql --no-psqlrc -p ${TEST_PGPORT} -d db0012 -c "SELECT * FROM t0012;" > ${TEST_BASE}/TEST-0012-after.out
-diff ${TEST_BASE}/TEST-0012-before.out ${TEST_BASE}/TEST-0012-after.out
+psql --no-psqlrc -p ${TEST_PGPORT} -d db0015 -c "SELECT * FROM t0015;" > ${TEST_BASE}/TEST-0015-after.out
+diff ${TEST_BASE}/TEST-0015-before.out ${TEST_BASE}/TEST-0015-after.out
 echo ''
 
 # clean up the temporal test data


### PR DESCRIPTION
Previously, users must execute 'pg_xlog_replay_resume()' or configure
'recovery_target_action' GUC parameter manually if the restored data
need archive recovery and users want to promote the server.

Since this limitation annoys users, this patch adds a new option
'--recovery-target-action'. If a user specifies this option when to
restore, pg_rman configures 'recovery_target_action' GUC parameter
automatically. So, the task which the user have to do is only to
start the server. After archive recovery is done, the server will
promote.