### PR TITLE
Add '--recovery-target-action' option for restore(#182)

### DIFF
--- a/docs/index-ja.html
+++ b/docs/index-ja.html
@@ -640,6 +640,12 @@ $ pg_ctl start
 <ul>
 <li>指定したリカバリ対象の直後で停止する (true) か、リカバリ対象の直前で停止する (false) かを指定します。デフォルトは true です。</li>
 </ul>
+
+<li><strong><code>--recovery-target-action {{ pause | promote | shutdown }}</code></strong>
+
+<ul>
+<li>リカバリ対象に到達した場合に、サーバがする動作を指定します。 デフォルトはpauseで、リカバリを休止することを意味します。 promoteは、リカバリの過程が終われば、サーバは接続の受け付けを始めることを意味します。 最後に、shutdownは、リカバリ対象に到達した後にサーバを停止します。1.3.12よりも後のバージョンで利用可能です。</li>
+</ul>
 </li>
 </ul>
 
@@ -987,6 +993,14 @@ $ pg_ctl start
 <td>指定可</td>
 <td>リカバリ到達点自体をリカバリするか</td>
 <td></td>
+</tr>
+<tr>
+<td></td>
+<td>&ndash;recovery-target-action</td>
+<td>RECOVERY_TARGET_ACTION</td>
+<td>指定可</td>
+<td>リカバリ対象に到達した場合にサーバがする動作</td>
+<td>1.3.12よりも後のバージョンで利用可能</td>
 </tr>
 <tr>
 <td></td>

--- a/docs/index.html
+++ b/docs/index.html
@@ -613,6 +613,13 @@ $ pg_ctl start
 <li>Specifies whether we stop just after the specified recovery target (true), or just before the recovery target (false). Default is true. 
 </ul>
 </li>
+<li><strong><code>--recovery-target-action {{ pause | promote | shutdown }}</code></strong>
+
+<ul>
+<li>Specifies what action the server should take once the recovery target is reached. The default is pause, which means recovery will be paused. promote means the recovery process will finish and the server will start to accept connections. Finally shutdown will stop the server after reaching the recovery target. This option is provided version higher than 1.3.12.</li>
+</ul>
+</li>
+</ul>
 </li>
 </ul>
 
@@ -958,6 +965,14 @@ $ pg_ctl start
 <td>Yes</td>
 <td>whether we stop just after the recovery target</td>
 <td></td>
+</tr>
+<tr>
+<td></td>
+<td>&ndash;recovery-target-action</td>
+<td>RECOVERY_TARGET_ACTION</td>
+<td>Yes</td>
+<td>action the server should take once the recovery target is reached</td>
+<td>This option is provided versions higher than 1.3.12</td>
 </tr>
 <tr>
 <td></td>

--- a/expected/option.out
+++ b/expected/option.out
@@ -45,6 +45,7 @@ Restore options:
   --recovery-target-xid     transaction ID up to which recovery will proceed
   --recovery-target-inclusive whether we stop just after the recovery target
   --recovery-target-timeline  recovering into a particular timeline
+  --recovery-target-action    action the server should take once the recovery target is reached
   --hard-copy                 copying archivelog not symbolic link
 
 Catalog options:

--- a/expected/restore.out
+++ b/expected/restore.out
@@ -47,24 +47,54 @@ OK: recovery-target-xid options works well.
 OK: recovery-target-inclusive=false works well.
 
 ###### RESTORE COMMAND TEST-0009 ######
+###### recovery with target action pause ######
+recovery-target-action=pause
+0
+0
+0
+0
+0
+OK: not promoted. recovery-target-action works well.
+
+###### RESTORE COMMAND TEST-0010 ######
+###### recovery with target action promote ######
+recovery-target-action=promote
+0
+0
+0
+0
+0
+OK: promoted. recovery-target-action works well.
+
+###### RESTORE COMMAND TEST-0011 ######
+###### recovery with target action shutdown ######
+recovery-target-action=shutdown
+0
+0
+0
+0
+0
+OK: server is stopped. recovery-target-action works well.
+
+###### RESTORE COMMAND TEST-0012 ######
 ###### recovery with hard-copy option ######
 0
 0
 OK: hard-copy option works well.
 
-###### RESTORE COMMAND TEST-0010 ######
+###### RESTORE COMMAND TEST-0013 ######
 ###### recovery from incremental backup after database creation ######
 0
 0
 0
 
-###### RESTORE COMMAND TEST-0011 ######
+###### RESTORE COMMAND TEST-0014 ######
 ###### vacuum shrinks a page between full and incremental backups ######
 0
 0
 0
 
-###### RESTORE COMMAND TEST-0012 ######
+###### RESTORE COMMAND TEST-0015 ######
 ###### vacuum shrinks a page between full and incremental backups(compressed) ######
 0
 0

--- a/expected/restore_checksum.out
+++ b/expected/restore_checksum.out
@@ -47,24 +47,54 @@ OK: recovery-target-xid options works well.
 OK: recovery-target-inclusive=false works well.
 
 ###### RESTORE COMMAND TEST-0009 ######
+###### recovery with target action pause ######
+recovery-target-action=pause
+0
+0
+0
+0
+0
+OK: not promoted. recovery-target-action works well.
+
+###### RESTORE COMMAND TEST-0010 ######
+###### recovery with target action promote ######
+recovery-target-action=promote
+0
+0
+0
+0
+0
+OK: promoted. recovery-target-action works well.
+
+###### RESTORE COMMAND TEST-0011 ######
+###### recovery with target action shutdown ######
+recovery-target-action=shutdown
+0
+0
+0
+0
+0
+OK: server is stopped. recovery-target-action works well.
+
+###### RESTORE COMMAND TEST-0012 ######
 ###### recovery with hard-copy option ######
 0
 0
 OK: hard-copy option works well.
 
-###### RESTORE COMMAND TEST-0010 ######
+###### RESTORE COMMAND TEST-0013 ######
 ###### recovery from incremental backup after database creation ######
 0
 0
 0
 
-###### RESTORE COMMAND TEST-0011 ######
+###### RESTORE COMMAND TEST-0014 ######
 ###### vacuum shrinks a page between full and incremental backups ######
 0
 0
 0
 
-###### RESTORE COMMAND TEST-0012 ######
+###### RESTORE COMMAND TEST-0015 ######
 ###### vacuum shrinks a page between full and incremental backups(compressed) ######
 0
 0

--- a/pg_rman.c
+++ b/pg_rman.c
@@ -48,6 +48,7 @@ static char		   *target_time;
 static char		   *target_xid;
 static char		   *target_inclusive;
 static char		   *target_tli_string;
+static char		   *target_action;
 static bool		is_hard_copy = false;
 
 /* delete configuration */
@@ -92,7 +93,8 @@ static pgut_option options[] =
 	{ 's',  8, "recovery-target-xid"		, &target_xid		, SOURCE_ENV },
 	{ 's',  9, "recovery-target-inclusive"	, &target_inclusive	, SOURCE_ENV },
 	{ 's', 10, "recovery-target-timeline"	, &target_tli_string, SOURCE_ENV },
-	{ 'b', 11, "hard-copy"	, &is_hard_copy		, SOURCE_ENV },
+	{ 's', 11, "recovery-target-action"		, &target_action	, SOURCE_ENV },
+	{ 'b', 12, "hard-copy"	, &is_hard_copy		, SOURCE_ENV },
 	/* catalog options */
 	{ 'b', 'a', "show-all"		, &show_all },
 	{ 0 }
@@ -221,7 +223,7 @@ main(int argc, char *argv[])
 	}
 	else if (pg_strcasecmp(cmd, "restore") == 0)
 		return do_restore(target_time, target_xid,
-					target_inclusive, target_tli_string, is_hard_copy);
+					target_inclusive, target_tli_string, target_action, is_hard_copy);
 	else if (pg_strcasecmp(cmd, "show") == 0)
 		return do_show(&range, show_detail, show_all);
 	else if (pg_strcasecmp(cmd, "validate") == 0)
@@ -285,6 +287,7 @@ pgut_help(bool details)
 	printf(_("  --recovery-target-xid     transaction ID up to which recovery will proceed\n"));
 	printf(_("  --recovery-target-inclusive whether we stop just after the recovery target\n"));
 	printf(_("  --recovery-target-timeline  recovering into a particular timeline\n"));
+	printf(_("  --recovery-target-action    action the server should take once the recovery target is reached\n"));
 	printf(_("  --hard-copy                 copying archivelog not symbolic link\n"));
 	printf(_("\nCatalog options:\n"));
 	printf(_("  -a, --show-all            show deleted backup too\n"));

--- a/pg_rman.h
+++ b/pg_rman.h
@@ -219,6 +219,7 @@ typedef struct pgRecoveryTarget
 	bool		xid_specified;
 	unsigned int	recovery_target_xid;
 	bool		recovery_target_inclusive;
+	const char	*recovery_target_action;
 } pgRecoveryTarget;
 
 typedef enum CompressionMode
@@ -265,6 +266,7 @@ extern int do_restore(const char *target_time,
 					  const char *target_xid,
 					  const char *target_inclusive,
 					  const char *target_tli_string,
+					  const char *target_action,
 					  bool is_hard_copy);
 
 /* in init.c */


### PR DESCRIPTION
Previously, users must execute 'pg_xlog_replay_resume()' or configure
'recovery_target_action' GUC parameter manually if the restored data
need archive recovery and users want to promote the server.

Since this limitation annoys users, this patch adds a new option
'--recovery-target-action'. If a user specifies this option when to
restore, pg_rman configures 'recovery_target_action' GUC parameter
automatically. So, the task which the user have to do is only to
start the server. After archive recovery is done, the server will
promote.