### PR TITLE
Add notes when using with HA clustring software #196

### DIFF
--- a/docs/index-ja.html
+++ b/docs/index-ja.html
@@ -269,7 +269,14 @@ pg_rmanがリストア中に未アーカイブの WAL をバックアップし�
 <p>リストア時に、<code>$PGDATA</code> に recovery.conf を生成します。
 必要に応じてこのファイルを編集してから PostgreSQL を起動して PITR を実行してください。</p>
 
-<p>リカバリ結果が確認できたら、速やかに全体バックアップを取得してください。</p>
+<p>リカバリ結果が確認できたら、速やかに全体バックアップを取得してください。また、pg_rmanが実施した
+recovery関連の設定を手動で削除することを推奨いたします。
+PostgreSQLのバージョン12から、recovery.confがpostgresql.confにマージされたことに起因し、HAクラスタソフトと連携させて動作させた場合などに、
+正常に動作しない可能性があるためです。一部のHAクラスタソフト（pacemaker）では、プライマリとして起動する場合でも、
+必ず、初めにスタンバイとして起動します。そのため、予期せず、リカバリ関連の設定が有効に働いてしまい、正常に起動しない可能性があります。
+例えば、PostgreSQLが12以上、pg_rmanが1.3.12よりも後のバージョンの場合は、<code>$PGDATA/postgresql.conf</code>に追加された<code>include</code>ディレクティブと、
+<code>$PGDATA/pg_rman_recovery.conf</code>を削除してください。
+</p>
 
 <p><code>--recovery-target-timeline</code> を指定しなかった場合は、制御ファイル(<code>$PGDATA/global/pg_control</code>) の最終チェックポイントタイムラインをターゲットとしてリストアします。
 pg_control が存在しない場合は、リストアのベースとなる全体バックアップのタイムラインをターゲットとしてリストアします。</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -246,7 +246,17 @@ STATUS=OK
 
 <p>PostgreSQL server should be stopped before restore. In addition, do not erase a original database cluster, because pg_rman has to check the timeline ID or data checksum status from it. Restore command will save unarchived transaction log and delete all database files. You can retry recovery until a new backup is taken. After restoring files, pg_rman create recovery.conf in <code>$PGDATA</code>. The conf file contains parameters to recovery, and you can also modify the file if needed.</p>
 
-<p>It is recommended to take a full backup as soon as possible after recovery is succeeded.</p>
+<p>It is recommended to take a full backup as soon as possible after recovery is succeeded and
+to remove the recovery-related parameters configured by pg_rman manually. The reason is that there
+is a case that even after recovery is done, PostgreSQL doesn't work with HA cluster software since
+recovery.conf is integrated to postgresql.conf after PostgreSQL's version is 12 or higher.
+Pacemaker which is a HA cluster software start postgresql server as standby at first,
+after that it decides it should promote or not.  So, the postgresql server doesn't start properly
+because the recovery-related parameter configured by pg_rman works as valid values unexpectedly.
+For example, in case using PostgreSQL's version is 12 or higher, and pg_rman's version is higher
+than 1.3.12, you need to remove an <code>include</code> directive in <code>$PGDATA/postgresql.conf</code>
+and <code>$PGDATA/pg_rman_recovery.conf</code>.
+</p>
 
 <p>If <code>--recovery-target-timeline</code> is not specified, the last checkpoint&rsquo;s TimeLineID in control file (<code>$PGDATA/global/pg_control</code>) will be a restore target. If pg_control is not present, TimeLineID in the full backup used by the restore will be a restore target.</p>
 

--- a/restore.c
+++ b/restore.c
@@ -404,7 +404,7 @@ base_backup_found:
 	if (!check)
 		ereport(INFO,
 			(errmsg("restore complete"),
-			 errhint("Recovery will start automatically when the PostgreSQL server is started.")));
+			 errhint("Recovery will start automatically when the PostgreSQL server is started. After the recovery is done, we recommend to remove recovery-related parameters configured by pg_rman.")));
 
 	return 0;
 }	


### PR DESCRIPTION
Add notes to warn users who use pg_rman with HA clustering
software (ex. pacemaker).

Since the recovery.conf and postgresql.conf was integrated
from postgresql version is 12. It leads that the recovery
related parameter configured by pg_rman works as valid
if used with pacemaker unexpectedly.

Need to backpatch-through: 12