### PR TITLE
update test version for 14rc1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
       shell: bash -xe {0}
       run: |
         declare -A versions=(
-          ["master"]="14beta3"
+          ["master"]="14rc1"
           ["REL_13_STABLE"]="13.4"
           ["REL_12_STABLE"]="12.8"
           ["REL_11_STABLE"]="11.13"


### PR DESCRIPTION
Update the test version for 14 RC1.

I checked the release notes and I think we don't need to update the codes.
https://www.postgresql.org/about/news/postgresql-14-rc-1-released-2309/