### PR TITLE
Fix the fail if a tablespace path has PGDATA(#141)

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -457,7 +457,7 @@ dir_print_mkdirs_sh(FILE *out, const parray *files, const char *root)
 		pgFile *file = (pgFile *) parray_get(files, i);
 		if (S_ISDIR(file->mode))
 		{
-			if (strstr(file->path, root) == file->path)
+			if (strstr(file->path, root) == file->path && file->path[strlen(root)] == '/')
 				fprintf(out, "mkdir -m 700 -p %s\n", file->path + strlen(root) + 1);
 			else
 				fprintf(out, "mkdir -m 700 -p %s\n", file->path);

--- a/expected/restore.out
+++ b/expected/restore.out
@@ -122,3 +122,8 @@ OK: new value is configured for recovery_target_timeline.
 0
 0
 
+###### RESTORE COMMAND TEST-0018 ######
+###### check to work even if the path of tablespace has $PGDATA ######
+0
+0
+

--- a/expected/restore_checksum.out
+++ b/expected/restore_checksum.out
@@ -122,3 +122,8 @@ OK: new value is configured for recovery_target_timeline.
 0
 0
 
+###### RESTORE COMMAND TEST-0018 ######
+###### check to work even if the path of tablespace has $PGDATA ######
+0
+0
+


### PR DESCRIPTION
Previously, if the server has a tablespace and
its path has PGDATA's path, the restore
fails because mkdirs.sh doesn't work.

For example, the following case fails to restore.

* PGDATA path: /tmp/pgdata
* tablespace path: /tmp/pgdata_tblspc

So, this patch fixes the case. The root cause
is the logic checking whether the file taking backup
is in tablespace or PGDATA.

Because it only considers their prefix, if the prefix
path of tablespace is the same as PGDATA, it decides
the file is in PGDATA.

So, this patch changes the logic to check it has '/'
after the prefix.