### PR TITLE
add type conversion

### DIFF
--- a/pgut/pgut.c
+++ b/pgut/pgut.c
@@ -410,7 +410,7 @@ parse_uint32(const char *value, uint32 *result)
 	if (errno == ERANGE || val != (uint64) ((uint32) val))
 		return false;
 
-	*result = val;
+	*result = (uint32) val;
 
 	return true;
 }


### PR DESCRIPTION
val is uint64 type but *result is uint32 type, so add  type conversion when assigning val to *result.