### PR TITLE
Clean up the code using "(expr) ? true : false"

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -597,7 +597,7 @@ dir_read_file_list(const char *root, const char *file_txt)
 		file->read_size = 0;
 		file->write_size = write_size;
 		file->crc = crc;
-		file->is_datafile = (type == 'F' ? true : false);
+		file->is_datafile = (type == 'F');
 		file->linked = NULL;
 		if (root)
 			sprintf(file->path, "%s/%s", root, path);


### PR DESCRIPTION
The commit fd0625c7a9 of PG had improved code where were already using a boolean or used an expression that led to zero or one, making the extra bits unnecessary.
This patch fixed the same problem in pg_rman.