### PR TITLE
fix the range of keep data generation

### DIFF
--- a/expected/option.out
+++ b/expected/option.out
@@ -74,7 +74,7 @@ Report bugs to <http://github.com/ossc-db/pg_rman/issues>.
 
 ###### COMMAND OPTION TEST-0002 ######
 ###### version option ######
-pg_rman 1.3.13
+pg_rman 1.3.14
 1
 
 ###### COMMAND OPTION TEST-0003 ######
@@ -136,40 +136,55 @@ ERROR: option --keep-arclog-days should be a 32bit signed integer: 'TRUE'
 
 ###### COMMAND OPTION TEST-0014 ######
 ###### invalid value in pg_rman.ini ######
-ERROR: option --keep-srvlog-files should be a 32bit signed integer: 'TRUE'
+ERROR: option --keep-srvlog-files should be between 1 and 2147483647: 'TRUE'
 12
 
 ###### COMMAND OPTION TEST-0015 ######
 ###### invalid value in pg_rman.ini ######
-ERROR: option --keep-srvlog-days should be a 32bit signed integer: 'TRUE'
+ERROR: option --keep-srvlog-days should be between 1 and 2147483647: 'TRUE'
 12
 
 ###### COMMAND OPTION TEST-0016 ######
 ###### invalid value in pg_rman.ini ######
-ERROR: option --keep-data-generations should be a 32bit signed integer: 'TRUE'
+ERROR: option --keep-data-generations should be between 1 and 2147483647: 'TRUE'
 12
 
 ###### COMMAND OPTION TEST-0017 ######
 ###### invalid value in pg_rman.ini ######
-ERROR: option -C, --smooth-checkpoint should be a boolean: 'FOO'
+ERROR: option --keep-data-generations should be between 1 and 2147483647: '0'
 12
 
 ###### COMMAND OPTION TEST-0018 ######
 ###### invalid value in pg_rman.ini ######
-ERROR: option -s, --with-serverlog should be a boolean: 'FOO'
+ERROR: option --keep-srvlog-files should be between 1 and 2147483647: '0'
 12
 
 ###### COMMAND OPTION TEST-0019 ######
 ###### invalid value in pg_rman.ini ######
-ERROR: option --hard-copy should be a boolean: 'FOO'
+ERROR: option --keep-srvlog-days should be between 1 and 2147483647: '0'
 12
 
 ###### COMMAND OPTION TEST-0020 ######
+###### invalid value in pg_rman.ini ######
+ERROR: option -C, --smooth-checkpoint should be a boolean: 'FOO'
+12
+
+###### COMMAND OPTION TEST-0021 ######
+###### invalid value in pg_rman.ini ######
+ERROR: option -s, --with-serverlog should be a boolean: 'FOO'
+12
+
+###### COMMAND OPTION TEST-0022 ######
+###### invalid value in pg_rman.ini ######
+ERROR: option --hard-copy should be a boolean: 'FOO'
+12
+
+###### COMMAND OPTION TEST-0023 ######
 ###### invalid option in pg_rman.ini ######
 ERROR: invalid option "TIMELINEID"
 12
 
-###### COMMAND OPTION TEST-0021 ######
+###### COMMAND OPTION TEST-0024 ######
 ###### check priority of several pg_rman.ini files ######
 ERROR: invalid backup-mode "ENV_PATH"
 12

--- a/pgut/pgut.c
+++ b/pgut/pgut.c
@@ -199,6 +199,11 @@ assign_option(pgut_option *opt, const char *optarg, pgut_optsrc src)
 					return;
 				message = "a 32bit signed integer";
 				break;
+		        case 'n':
+			        if (parse_posi(optarg, opt->var))
+					return;
+				message = "between 1 and 2147483647";
+				break;
 			case 'u':
 				if (parse_uint32(optarg, opt->var))
 					return;
@@ -384,6 +389,40 @@ parse_int32(const char *value, int32 *result)
 	*result = val;
 
 	return true;
+}
+
+
+/*
+ * Parse string as positive number.
+ * valid range: 1 ~ 2147483647
+ */
+
+bool
+parse_posi(const char *value, int32 *result)
+{
+        int64   val;
+        char   *endptr;
+
+        if (strcmp(value, INFINITE_STR) == 0)
+        {
+                *result = INT_MAX;
+                return true;
+        }
+
+        errno = 0;
+        val = strtol(value, &endptr, 0);
+        if (endptr == value || *endptr)
+                return false;
+
+        if (errno == ERANGE || val != (int64) ((int32) val))
+                return false;
+
+        if (val < 0 || val == 0)
+		return false;
+
+        *result = val;
+
+        return true;
 }
 
 /*

--- a/sql/option.sh
+++ b/sql/option.sh
@@ -165,32 +165,54 @@ echo ''
 echo '###### COMMAND OPTION TEST-0017 ######'
 echo '###### invalid value in pg_rman.ini ######'
 init_catalog
-echo "SMOOTH_CHECKPOINT=FOO" >> ${BACKUP_PATH}/pg_rman.ini
+echo "KEEP_DATA_GENERATIONS=0" >> ${BACKUP_PATH}/pg_rman.ini
 pg_rman backup -B ${BACKUP_PATH} -A ${ARCLOG_PATH} -b full -p ${TEST_PGPORT};echo $?
 echo ''
 
 echo '###### COMMAND OPTION TEST-0018 ######'
 echo '###### invalid value in pg_rman.ini ######'
 init_catalog
-echo "WITH_SERVERLOG=FOO" >> ${BACKUP_PATH}/pg_rman.ini
+echo "KEEP_SRVLOG_FILES=0" >> ${BACKUP_PATH}/pg_rman.ini
 pg_rman backup -B ${BACKUP_PATH} -A ${ARCLOG_PATH} -b full -p ${TEST_PGPORT};echo $?
 echo ''
 
 echo '###### COMMAND OPTION TEST-0019 ######'
 echo '###### invalid value in pg_rman.ini ######'
 init_catalog
+echo "KEEP_SRVLOG_DAYS=0" >> ${BACKUP_PATH}/pg_rman.ini
+pg_rman backup -B ${BACKUP_PATH} -A ${ARCLOG_PATH} -b full -p ${TEST_PGPORT};echo $?
+echo ''
+
+
+echo '###### COMMAND OPTION TEST-0020 ######'
+echo '###### invalid value in pg_rman.ini ######'
+init_catalog
+echo "SMOOTH_CHECKPOINT=FOO" >> ${BACKUP_PATH}/pg_rman.ini
+pg_rman backup -B ${BACKUP_PATH} -A ${ARCLOG_PATH} -b full -p ${TEST_PGPORT};echo $?
+echo ''
+
+echo '###### COMMAND OPTION TEST-0021 ######'
+echo '###### invalid value in pg_rman.ini ######'
+init_catalog
+echo "WITH_SERVERLOG=FOO" >> ${BACKUP_PATH}/pg_rman.ini
+pg_rman backup -B ${BACKUP_PATH} -A ${ARCLOG_PATH} -b full -p ${TEST_PGPORT};echo $?
+echo ''
+
+echo '###### COMMAND OPTION TEST-0022 ######'
+echo '###### invalid value in pg_rman.ini ######'
+init_catalog
 echo "HARD_COPY=FOO" >> ${BACKUP_PATH}/pg_rman.ini
 pg_rman backup -B ${BACKUP_PATH} -A ${ARCLOG_PATH} -b full -p ${TEST_PGPORT};echo $?
 echo ''
 
-echo '###### COMMAND OPTION TEST-0020 ######'
+echo '###### COMMAND OPTION TEST-0023 ######'
 echo '###### invalid option in pg_rman.ini ######'
 init_catalog
 echo "TIMELINEID=1" >> ${BACKUP_PATH}/pg_rman.ini
 pg_rman backup -B ${BACKUP_PATH} -A ${ARCLOG_PATH} -b full -p ${TEST_PGPORT};echo $?
 echo ''
 
-echo '###### COMMAND OPTION TEST-0021 ######'
+echo '###### COMMAND OPTION TEST-0024 ######'
 echo '###### check priority of several pg_rman.ini files ######'
 init_catalog
 mkdir -p ${BACKUP_PATH}/conf_path_a


### PR DESCRIPTION
If you set keep_data_generations = 0, the backup you got will be deleted immediately,
I think the setting like keep_data_generations = 0 is meaningless.
So, In this PR, the minimum value of the setting range of keep_data_generations has been changed to 1.
In addition, keep_srvlog_days, keep_srvlog_files have been modified in the same way.