### PR TITLE
fix typo

### DIFF
--- a/restore.c
+++ b/restore.c
@@ -131,7 +131,7 @@ do_restore(const char *target_time,
 		ereport(ERROR,
 			(errcode(ERROR_ARGS),
 			 errmsg("could not create recovery.conf or"
-					"add recovery-related options to postgresql.conf(after PG12)"),
+					" add recovery-related options to postgresql.conf(after PG12)"),
 			 errdetail("The specified options are invalid.")));
 
 	/* get list of backups. (index == 0) is the last backup */

--- a/restore.c
+++ b/restore.c
@@ -130,8 +130,8 @@ do_restore(const char *target_time,
 	if(rt == NULL)
 		ereport(ERROR,
 			(errcode(ERROR_ARGS),
-			 errmsg("could not create recovery.conf or"
-					" add recovery-related options to postgresql.conf(after PG12)"),
+			 errmsg("could not create recovery.conf or "
+					"add recovery-related options to postgresql.conf(after PG12)"),
 			 errdetail("The specified options are invalid.")));
 
 	/* get list of backups. (index == 0) is the last backup */
@@ -1398,7 +1398,7 @@ checkIfCreateRecoveryConf(const char *target_time,
 		else
 			ereport(ERROR,
 				(errcode(ERROR_ARGS),
-				 errmsg("could not create recovery.conf or"
+				 errmsg("could not create recovery.conf or "
 						"add recovery-related options to postgresql.conf(after PG12) with %s", target_time)));
 	}
 
@@ -1411,7 +1411,7 @@ checkIfCreateRecoveryConf(const char *target_time,
 		else
 			ereport(ERROR,
 				(errcode(ERROR_ARGS),
-				 errmsg("could not create recovery.conf or"
+				 errmsg("could not create recovery.conf or "
 						" add recovery-related options to postgresql.conf(after PG12) with %s", target_xid)));
 	}
 
@@ -1422,7 +1422,7 @@ checkIfCreateRecoveryConf(const char *target_time,
 		else
 			ereport(ERROR,
 				(errcode(ERROR_ARGS),
-				 errmsg("could not create recovery.conf or"
+				 errmsg("could not create recovery.conf or "
 						"add recovery-related options to postgresql.conf(after PG12) with %s", target_inclusive)));
 	}
 
@@ -1437,7 +1437,7 @@ checkIfCreateRecoveryConf(const char *target_time,
 		} else
 			ereport(ERROR,
 				(errcode(ERROR_ARGS),
-				 errmsg("could not create recovery.conf or"
+				 errmsg("could not create recovery.conf or "
 						"add recovery-related options to postgresql.conf(after PG12) with %s", target_action)));
 	}
 

--- a/restore.c
+++ b/restore.c
@@ -1412,7 +1412,7 @@ checkIfCreateRecoveryConf(const char *target_time,
 			ereport(ERROR,
 				(errcode(ERROR_ARGS),
 				 errmsg("could not create recovery.conf or "
-						" add recovery-related options to postgresql.conf(after PG12) with %s", target_xid)));
+						"add recovery-related options to postgresql.conf(after PG12) with %s", target_xid)));
 	}
 
 	if(target_inclusive)

--- a/restore.c
+++ b/restore.c
@@ -949,7 +949,7 @@ remove_standby_signal(void)
 			}
 			ereport(INFO,
 				(errmsg("removed standby.signal"),
-				 errhint("if you want to start as standby, additional manual"
+				 errhint("if you want to start as standby, additional manual "
 						"setups to make standby.signal and so on are required")));
 		}
 	}


### PR DESCRIPTION
bash-4.4$ pg_rman restore --recovery-target-time '2022-03-15 02:24:122'
bash-4.4$ /usr/pgsql-14/bin/pg_rman restore --recovery-target-time '2022-03-15 0
2:24:122'
ERROR: could not create recovery.conf oradd recovery-related options to postgres                                                         ql.conf(after PG12) with 2022-03-15 02:24:122

I think the message [ERROR: could not create recovery.conf or add recovery-related options to postgres                                                         ql.conf(after PG12) with ] is right.

oradd →　or add