### PR TITLE
fix sscanf limits

### DIFF
--- a/backup.c
+++ b/backup.c
@@ -1389,7 +1389,7 @@ backup_cleanup(bool fatal, void *userdata)
 	 */
 	if (current.status == BACKUP_STATUS_RUNNING && current.end_time == 0)
 	{
-		elog(DEBUG, "update bakckup status from RUNNING to ERROR");
+		elog(DEBUG, "update backup status from RUNNING to ERROR");
 		current.end_time = time(NULL);
 		current.status = BACKUP_STATUS_ERROR;
 		pgBackupWriteIni(&current);


### PR DESCRIPTION
Make sure that the string parsing is limited by the size of the destination buffer.