### PR TITLE
add start_postgres function and stop_function to REL_11_STABLE and REL_10_STABLE

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -457,7 +457,7 @@ dir_print_mkdirs_sh(FILE *out, const parray *files, const char *root)
 		pgFile *file = (pgFile *) parray_get(files, i);
 		if (S_ISDIR(file->mode))
 		{
-			if (strstr(file->path, root) == file->path)
+			if (strstr(file->path, root) == file->path && file->path[strlen(root)] == '/')
 				fprintf(out, "mkdir -m 700 -p %s\n", file->path + strlen(root) + 1);
 			else
 				fprintf(out, "mkdir -m 700 -p %s\n", file->path);

--- a/expected/restore.out
+++ b/expected/restore.out
@@ -100,3 +100,8 @@ OK: hard-copy option works well.
 0
 0
 
+###### RESTORE COMMAND TEST-0018 ######
+###### check to work even if the path of tablespace has $PGDATA ######
+0
+0
+

--- a/expected/restore_checksum.out
+++ b/expected/restore_checksum.out
@@ -100,3 +100,8 @@ OK: hard-copy option works well.
 0
 0
 
+###### RESTORE COMMAND TEST-0018 ######
+###### check to work even if the path of tablespace has $PGDATA ######
+0
+0
+

--- a/sql/restore.sh
+++ b/sql/restore.sh
@@ -441,6 +441,37 @@ psql --no-psqlrc -p ${TEST_PGPORT} -d db0015 -c "SELECT * FROM t0015;" > ${TEST_
 diff ${TEST_BASE}/TEST-0015-before.out ${TEST_BASE}/TEST-0015-after.out
 echo ''
 
+echo '###### RESTORE COMMAND TEST-0018 ######'
+echo '###### check to work even if the path of tablespace has $PGDATA ######'
+init_backup
+start_postgres
+
+TBLSPC_PATH_HAS_PGDATA_PATH=${PGDATA_PATH}_test_tbl/test
+TEST_DB=test
+
+mkdir -p ${TBLSPC_PATH_HAS_PGDATA_PATH}
+psql --no-psqlrc -p ${TEST_PGPORT} -d postgres > /dev/null 2>&1 << EOF
+CREATE TABLESPACE ${TEST_DB} LOCATION '${TBLSPC_PATH_HAS_PGDATA_PATH}';
+CREATE DATABASE ${TEST_DB} TABLESPACE = ${TEST_DB};
+EOF
+
+pgbench -p ${TEST_PGPORT} -i -s 10 -d ${TEST_DB} > /dev/null 2>&1
+psql -p ${TEST_PGPORT} --no-psqlrc -d ${TEST_DB} -c "SELECT * FROM pgbench_branches;" > ${TEST_BASE}/TEST-0018-before.out
+
+pg_rman backup -B ${BACKUP_PATH} -b full -Z -p ${TEST_PGPORT} -d postgres --quiet;echo $?
+pg_rman validate -B ${BACKUP_PATH} --quiet
+stop_postgres
+pg_rman restore -B ${BACKUP_PATH} --quiet;echo $?
+start_postgres
+sleep 1
+
+psql -p ${TEST_PGPORT} --no-psqlrc -d ${TEST_DB} -c "SELECT * FROM pgbench_branches;" > ${TEST_BASE}/TEST-0018-after.out
+diff ${TEST_BASE}/TEST-0018-before.out ${TEST_BASE}/TEST-0018-after.out
+
+stop_postgres
+rm -r ${TBLSPC_PATH_HAS_PGDATA_PATH}
+echo ''
+
 # clean up the temporal test data
 pg_ctl stop -m immediate > /dev/null 2>&1
 rm -fr ${PGDATA_PATH}

--- a/sql/restore.sh
+++ b/sql/restore.sh
@@ -125,6 +125,16 @@ function server_is_running
 	pg_ctl status | grep "server is running" | wc -l
 }
 
+function start_postgres
+{
+	pg_ctl start -w -t 600 > /dev/null 2>&1
+}
+
+function stop_postgres
+{
+	pg_ctl stop -m fast >  /dev/null 2>&1
+}
+
 function pg_is_in_recovery
 {
 	psql -tA -p ${TEST_PGPORT} --no-psqlrc -d pgbench -c "SELECT pg_is_in_recovery();"


### PR DESCRIPTION
add start_postgres function and stop_function to REL_11_STABLE and REL_10_STABLE.
PG12 and later versions added start_postgres and stop_postgres functions.
PG11 and earlier versions did not add these two functions, which caused regression test failures.

The reason for not adding them in pre-PG11 versions is that
The PR that added the start_postgres and stop_postgres functions is modifications related to postgresql.conf