### PR TITLE
Add description for compress target to doc

### DIFF
--- a/docs/index-ja.html
+++ b/docs/index-ja.html
@@ -638,7 +638,7 @@ $ pg_ctl start
 <li><strong><code>-Z</code> / <code>--compress-data</code></strong>
 
 <ul>
-<li>zlibを用いてバックアップファイルを圧縮します。省略時は圧縮なしです。</li>
+<li>zlibを用いてバックアップファイルを圧縮します。省略時は圧縮なしです。圧縮時は、設定ファイルやbackup_labelファイルもふくめ、すべてのバックアップファイルが圧縮されます。</li>
 </ul>
 </li>
 <li><strong><code>-C</code> / <code>--smooth-checkpoint</code></strong>

--- a/docs/index.html
+++ b/docs/index.html
@@ -625,7 +625,7 @@ $ pg_ctl start
 <li><strong><code>-Z</code> / <code>--compress-data</code></strong>
 
 <ul>
-<li>Compress backup files with zlib if specified.</li>
+<li>Compress backup files with zlib if specified. When the option is omitted, no compression is performed. When compressing, all backup files are compressed, including configuration files and backup_label.</li>
 </ul>
 </li>
 <li><strong><code>-C</code> / <code>--smooth-checkpoint</code></strong>


### PR DESCRIPTION
When pg_rman compresses backup files, it compresses not only the data files, but also the configuration file and backup_label. These files are not readable by external tools, so I would need to describe the reason for this in the documentation.