### PR TITLE
parray_new() memory leak !

### DIFF
--- a/backup.c
+++ b/backup.c
@@ -2073,6 +2073,10 @@ add_files(parray *files, const char *root, bool add_root, bool is_pgdata)
 		file->is_datafile = true;
 	}
 	parray_concat(files, list_file);
+
+	if (list_file)
+		parray_walk(list_file, pgFileFree);
+	parray_free(list_file);
 }
 
 /*

--- a/backup.c
+++ b/backup.c
@@ -480,6 +480,7 @@ do_backup_database(parray *backup_list, pgBackupOption bkupopt)
 				}
 			}
 			parray_concat(files, snapshot_files);
+			parray_free(snapshot_files);
 		}
 
 		/*
@@ -2074,8 +2075,6 @@ add_files(parray *files, const char *root, bool add_root, bool is_pgdata)
 	}
 	parray_concat(files, list_file);
 
-	if (list_file)
-		parray_walk(list_file, pgFileFree);
 	parray_free(list_file);
 }
 

--- a/delete.c
+++ b/delete.c
@@ -501,6 +501,8 @@ int do_purge(void)
 			else
 				elog(INFO, _("DELETED backup \"%s\" is purged"), timestamp);
 		}
+
+		parray_free(files);
 	}
 	return 0;
 }

--- a/dir.c
+++ b/dir.c
@@ -293,6 +293,8 @@ dir_list_file(parray *files, const char *root, const char *exclude[], bool omit_
 		fclose(black_list_file);
 		parray_qsort(black_list, BlackListCompare);
 		dir_list_file_internal(files, root, exclude, omit_symlink, add_root, black_list);
+
+		parray_free(black_list);
 	}
 	else
 		dir_list_file_internal(files, root, exclude, omit_symlink, add_root, NULL);


### PR DESCRIPTION
some function call **parray_new()** and save return value in local variable.
Before the function exits, we need call **parray_free()** to free  the buffer it holds, 
otherwise, it will cause **memory leak**.