### PR TITLE
Support PostgreSQL v15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,19 +4,19 @@ on:
   push:
     branches:
       - master
+      - REL_15_STABLE
       - REL_14_STABLE
       - REL_13_STABLE
       - REL_12_STABLE
       - REL_11_STABLE
-      - REL_10_STABLE
   pull_request:
     branches:
       - master
+      - REL_15_STABLE
       - REL_14_STABLE
       - REL_13_STABLE
       - REL_12_STABLE
       - REL_11_STABLE
-      - REL_10_STABLE
   schedule:
     - cron: "0 1 * * SUN"      # only master
 
@@ -41,12 +41,12 @@ jobs:
       shell: bash -xe {0}
       run: |
         declare -A versions=(
-          ["master"]="14.0"
-          ["REL_14_STABLE"]="14.0"
-          ["REL_13_STABLE"]="13.4"
-          ["REL_12_STABLE"]="12.8"
-          ["REL_11_STABLE"]="11.13"
-          ["REL_10_STABLE"]="10.18"
+          ["master"]="15.1"
+          ["REL_15_STABLE"]="15.1"
+          ["REL_14_STABLE"]="14.6"
+          ["REL_13_STABLE"]="13.9"
+          ["REL_12_STABLE"]="12.13"
+          ["REL_11_STABLE"]="11.18"
         )
         [ -z "${versions[${{ env.BRANCH }}]}" ] && exit 1         # check if the key exists
         echo "PGVERSION=${versions[${{ env.BRANCH }}]}" >> $GITHUB_ENV

--- a/pgut/pgut.c
+++ b/pgut/pgut.c
@@ -16,6 +16,7 @@
 #include <signal.h>
 #include <time.h>
 #include <unistd.h>
+#include <pwd.h>
 
 #include "pgut.h"
 

--- a/sql/arc_srv_log_management.sh
+++ b/sql/arc_srv_log_management.sh
@@ -47,6 +47,7 @@ wal_level = hot_standby
 log_directory = '${SRVLOG_PATH}'
 archive_mode = on
 archive_command = 'cp %p ${ARCLOG_PATH}/%f'
+log_checkpoints = off
 EOF
 
 	# start PostgreSQL


### PR DESCRIPTION
* Renamed the functions pg_start_backup()/pg_stop_backup() to pg_backup_start()/pg_backup_stop() and change the arguments of pg_backup_stop() pg_rman already supported non-exclusive mode, so we just renamed the function names and change the arguments to keeps the behavior.

* Default log_checkpoints for regression test is off. In PostgreSQL15, the default value of log_checkpoints is on. The checkpoints are automatically triggered when regression tests are run. The test failed because some log files was updated timestamp and the wrong log was deleted. So, we turned this feature off before running the test.