### PR TITLE
Fix compile warning -Wunused-but-set-variable

### DIFF
--- a/data.c
+++ b/data.c
@@ -1267,11 +1267,13 @@ figure_out_segno(char *filepath)
 
 	if ((filename = strrchr(filepath, '/')) != NULL)
 	{
-		int		scanned;
 		unsigned int	relfilenode = 0;
-
-		scanned = sscanf((char *) filename + 1, "%u.%d", &relfilenode, &segno);
+#ifdef USE_ASSERT_CHECKING
+		int scanned = sscanf((char *) filename + 1, "%u.%d", &relfilenode, &segno);
 		Assert(scanned > 0);
+#else
+		sscanf((char *) filename + 1, "%u.%d", &relfilenode, &segno);
+#endif
 	}
 
 	return segno;


### PR DESCRIPTION
Compiling pg_rman with PostgreSQL and disabled assertions triggers a -Wunused-but-set-variable warning.

```
#16 0.335 gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -march=x86-64-v2 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -I/usr/pgsql-13/include -lm -I. -I./ -I/usr/pgsql-13/include/server -I/usr/pgsql-13/include/internal  -D_GNU_SOURCE -I/usr/include/libxml2  -I/usr/include  -c -o validate.o validate.c
#16 0.418 data.c: In function 'figure_out_segno':
#16 0.419 data.c:1270:33: warning: variable 'scanned' set but not used [-Wunused-but-set-variable]
#16 0.419  1270 |                 int             scanned;
#16 0.419       |                                 ^~~~~~~
```
