### PR TITLE
Use $(whoami) instead of $USER

### DIFF
--- a/sql/backup_from_standby.sh
+++ b/sql/backup_from_standby.sh
@@ -91,9 +91,9 @@ EOF
 local   replication     postgres                                trust
 host    replication     postgres        127.0.0.1/32            trust
 host    replication     postgres        ::1/128                 trust
-local   replication     $USER                                trust
-host    replication     $USER        127.0.0.1/32            trust
-host    replication     $USER        ::1/128                 trust
+local   replication     $(whoami)                               trust
+host    replication     $(whoami)       127.0.0.1/32            trust
+host    replication     $(whoami)       ::1/128                 trust
 EOF
 
 


### PR DESCRIPTION
Use $(whoami) instead of $USER.
The reasons are as follows.
- If the environment in which the shell script is executed is not a login shell, the variable $USER may not be set. For example, in a Docker container, an interactive shell is started unless you specify otherwise.
- $USER may be overridden, in which case the shell script will not work properly.