### PR TITLE
Add *.bc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@
 /regression.diffs
 /regression.out
 /results
+
+# Bitcodes
+*.bc


### PR DESCRIPTION
When running `make`, *.bc is generated but there is no entry in `.gitignore`.
So, I added.