### PR TITLE
Update actions/cache v2 to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: cache builded resources
       id: cache-postgresql-core
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: "~/pgsql/${{ env.PGVERSION }}"
         key: ${{ env.PGVERSION }}-${{ env.CACHE_VERSION }}


### PR DESCRIPTION
actions/cache v1-v2 and actions/toolkit cache package closing down.
See https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down