### PR TITLE
Fix compile warning -Wmaybe-uninitialized

### DIFF
--- a/init.c
+++ b/init.c
@@ -40,7 +40,7 @@ do_init(void)
 
 	struct dirent **dp;
 	int results;
-	uint64      sysid;
+	uint64      sysid = 0;
 	ControlFileData *controlFile;
 	bool crc_ok;
 


### PR DESCRIPTION
Compile error has occuered, so I fixed it.

```
In file included from /home/shinya/pgsql/17/include/server/c.h:1370,
                 from /home/shinya/pgsql/17/include/server/postgres_fe.h:25,
                 from pg_rman.h:13,
                 from init.c:10:
init.c: In function ‘do_init’:
/home/shinya/pgsql/17/include/server/port.h:242:33: warning: ‘sysid’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  242 | #define fprintf                 pg_fprintf
      |                                 ^~~~~~~~~~
init.c:43:21: note: ‘sysid’ was declared here
   43 |         uint64      sysid;
      |                     ^~~~~
```