### PR TITLE
Add the missing loop exit condition based on Z_STREAM_END 

### DIFF
--- a/data.c
+++ b/data.c
@@ -90,7 +90,7 @@ doDeflate(z_stream *zp, size_t in_size, size_t out_size, void *inbuf,
 
 		zp->next_out = outbuf;
 		zp->avail_out = out_size;
-	} while (zp->avail_in != 0);
+	} while (zp->avail_in != 0 && status != Z_STREAM_END);
 
 	return status;
 }


### PR DESCRIPTION
doDeflate() function has no loop exit condition if deflate() returns Z_STREAM_END. 
Therefore, this code could potentially cause an infinite loop. 
Similar code using zlib in PostgreSQL has such an exit condition, so it would be desirable to do the same for pg_rman.
