### PR TITLE
Fix an infinite loop when backing up DB cluster with many tablespaces

### DIFF
--- a/data.c
+++ b/data.c
@@ -1200,7 +1200,7 @@ write_stop_backup_file(pgBackup *backup, const char *buf, int len, const char *f
 #ifdef HAVE_LIBZ
 		if (backup->compress_data)
 			doDeflate(&z, write_len, sizeof(outbuf), (void *) writebuf, outbuf, NULL,
-					  fp, &crc, &write_size, Z_FINISH);
+					  fp, &crc, &write_size, Z_NO_FLUSH);
 		else
 #endif
 		{
@@ -1221,6 +1221,11 @@ write_stop_backup_file(pgBackup *backup, const char *buf, int len, const char *f
 #ifdef HAVE_LIBZ
 	if (backup->compress_data)
 	{
+		while (doDeflate(&z, 0, sizeof(outbuf), NULL, outbuf, NULL,
+				  fp, &crc, &write_size, Z_FINISH) != Z_STREAM_END)
+		{
+		}
+
 		if (deflateEnd(&z) != Z_OK)
 		{
 			fclose(fp);


### PR DESCRIPTION
Hi,

**Problem**
I noticed that when the number of tablespaces is large, attempting to take a full backup with compression using the following command causes pg_rman to hang and never complete:

  $ pg_rman backup --backup-mode=full -Z

This issue can be reproduced , for example, by creating around 200 tablespaces with LOCATION strings such as '/home/postgres/pgsql/master/tblspc/ts100'.

**Analysis**
When the number of tablespaces is large, the resulting tablespace_map can become large as well. In such cases, [deflate(z, Z_FINISH)](https://github.com/ossc-db/pg_rman/blob/0ab83ca41822ee4eddc86386990ef60c8f76f949/data.c#L1202) returns Z_BUF_ERROR due to insufficient avail_out buffer size. 

According to the zlib documentation, if Z_BUF_ERROR is returned with Z_FINISH, the function must be called again with increased avail_out until Z_STREAM_END is returned:

>  -- zlib-1.2.11/zlib.h
>   If the parameter flush is set to Z_FINISH, pending input is processed,
>   pending output is flushed and deflate returns with Z_STREAM_END if there was
>   enough output space. **If deflate returns with** Z_OK or **Z_BUF_ERROR, this**
>   **function must be called again with Z_FINISH and more output space** (updated
>   avail_out) but no more input data, until it returns with Z_STREAM_END or an
>   error.  After deflate has returned Z_STREAM_END, the only possible operations
>   on the stream are deflateReset or deflateEnd

However, in the current pg_rman implementation, the output buffer size (out_size) passed to do_deflate() is fixed. This results in repeated failed calls to deflate() with the same buffer size, and [infinite loop in doDeflate()](https://github.com/ossc-db/pg_rman/blob/0ab83ca41822ee4eddc86386990ef60c8f76f949/data.c#L51-L93).

**Fix**
According to the official zlib usage guidelines ([zlib_how.html](https://www.zlib.net/zlib_how.html)), the proper sequence is to:

1. Call deflate(z, Z_NO_FLUSH) repeatedly until all input is consumed.
2. Then call deflate(z, Z_FINISH)

This PR updates the code that compresses tablespace_map to follow this approach, aligning it with how other parts of pg_rman use doDeflate().

Some thoughts:

- It might be ideal to add a regression test for this behavior (But I chose not to include one in this PR now due to the already long execution time of the test suite)
- Although the updated code introduces a loop that could theoretically result in an infinite loop, it follows the same zlib usage pattern already used in pg_rman for compressing user data—code that is likely exercised frequently in practice. Therefore, I believe the risk of such a loop occurring is very low.


What do you think?