### PR TITLE
Fix a compile warning in backup.c

### DIFF
--- a/backup.c
+++ b/backup.c
@@ -1738,7 +1738,8 @@ delete_old_files(const char *root,
 		for (j = parray_num(files) - 1; j >= 0; j--)
 		{
 			pgFile *file2 = (pgFile *)parray_get(files, j);
-			if (strstr(file2->path, file->path) == file2->path)
+			if (file->path[0] != '\0' && file2->path[0] != '\0' &&
+				strstr(file2->path, file->path) == file2->path)
 			{
 				file2 = (pgFile *)parray_remove(files, j);
 				elog(INFO, "delete \"%s\"",


### PR DESCRIPTION
I encountered a compilation warning on RHEL 10 when building the backup.c file.

```
backup.c: In function 'delete_old_files':
backup.c:1741:29: warning: 'strstr' reading 1 or more bytes from a region of size 0 [-Wstringop-overread]
 1741 |                         if (strstr(file2->path, file->path) == file2->path)
      |                             ^
lto1: note: source object is likely at address zero
```

To fix this, just checking `file->path` and `file2->path` is not null-terminated string.
Thoughts?